### PR TITLE
Travis must always test current branch, not gopkg.in/pg.v1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ install:
   - go get github.com/go-sql-driver/mysql
   - go get github.com/lib/pq
   - go get launchpad.net/gocheck
-  - go get gopkg.in/pg.v1
+  - mkdir -p $HOME/gopath/src/gopkg.in
+  - ln -s `pwd` $HOME/gopath/src/gopkg.in/pg.v1
 
 before_script:
   - psql -c 'CREATE DATABASE test;' -U postgres


### PR DESCRIPTION
It appears that until now travis tested `gopkg.in/pg.v1` package --- that is, whichever commit was tagged as `v1`. So `master` branch itself and pull requests went untested.

After changing travis config, it turns out that "Fix setting zero values on NULL" actually doesn't work: https://travis-ci.org/go-pg/pg/jobs/27562268
