### PR TITLE
Use faster collections in examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,15 @@ type User struct {
 	Emails []string
 }
 
-type Users []*User
+type Users struct {
+	C []User
+}
 
 var _ pg.Collection = &Users{}
 
 func (users *Users) NewRecord() interface{} {
-	u := &User{}
-	*users = append(*users, u)
-	return u
+	users.C = append(users.C, User{})
+	return &users.C[len(users.C)-1]
 }
 
 func CreateUser(db *pg.DB, user *User) error {
@@ -68,10 +69,10 @@ func GetUser(db *pg.DB, id int64) (*User, error) {
 	return &user, err
 }
 
-func GetUsers(db *pg.DB) ([]*User, error) {
+func GetUsers(db *pg.DB) ([]User, error) {
 	var users Users
 	_, err := db.Query(&users, `SELECT * FROM users`)
-	return users, err
+	return users.C, err
 }
 
 func ExampleDB_Query() {
@@ -113,7 +114,7 @@ func ExampleDB_Query() {
 	fmt.Println(user)
 	fmt.Println(users[0], users[1])
 	// Output: &{1 admin [admin1@admin admin2@admin]}
-	// &{1 admin [admin1@admin admin2@admin]} &{2 root [root1@root root2@root]}
+	// {1 admin [admin1@admin admin2@admin]} {2 root [root1@root root2@root]}
 }
 ```
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -110,8 +110,8 @@ func BenchmarkQueryRows(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
-			if len(rs) != 1000 {
-				b.Fatalf("got %d, wanted 1000", len(rs))
+			if len(rs.C) != 1000 {
+				b.Fatalf("got %d, wanted 1000", len(rs.C))
 			}
 		}
 	})
@@ -499,14 +499,15 @@ func (r *record) GetStr3() string {
 	return r.Str3
 }
 
-type records []record
+type records struct {
+	C []record
+}
 
 var _ pg.Collection = &records{}
 
 func (rs *records) NewRecord() interface{} {
-	r := record{}
-	*rs = append(*rs, r)
-	return &r
+	rs.C = append(rs.C, record{})
+	return &rs.C[len(rs.C)-1]
 }
 
 func seedDB(db *pg.DB) error {

--- a/db.go
+++ b/db.go
@@ -92,7 +92,7 @@ func (opt *Options) getPoolSize() int {
 
 func (opt *Options) getPoolTimeout() time.Duration {
 	if opt == nil || opt.PoolTimeout == 0 {
-		return 3 * time.Second
+		return time.Second
 	}
 	return opt.PoolTimeout
 }

--- a/example_complexQuery_test.go
+++ b/example_complexQuery_test.go
@@ -32,14 +32,15 @@ type Article struct {
 	CategoryId int
 }
 
-type Articles []*Article
+type Articles struct {
+	C []Article
+}
 
 var _ pg.Collection = &Articles{}
 
 func (articles *Articles) NewRecord() interface{} {
-	a := &Article{}
-	*articles = append(*articles, a)
-	return a
+	articles.C = append(articles.C, Article{})
+	return &articles.C[len(articles.C)-1]
 }
 
 func CreateArticle(db *pg.DB, article *Article) error {
@@ -56,7 +57,7 @@ func GetArticle(db *pg.DB, id int64) (*Article, error) {
 	return article, err
 }
 
-func GetArticles(db *pg.DB, f *ArticleFilter) ([]*Article, error) {
+func GetArticles(db *pg.DB, f *ArticleFilter) ([]Article, error) {
 	var articles Articles
 	_, err := db.Query(&articles, `
 		SELECT * FROM articles WHERE 1=1 ?FilterName ?FilterCategory
@@ -64,7 +65,7 @@ func GetArticles(db *pg.DB, f *ArticleFilter) ([]*Article, error) {
 	if err != nil {
 		return nil, err
 	}
-	return articles, nil
+	return articles.C, nil
 }
 
 func Example_complexQuery() {
@@ -100,6 +101,6 @@ func Example_complexQuery() {
 	}
 	fmt.Printf("%d %v\n", len(articles), articles[0])
 
-	// Output: 2 &{1 article1 1} &{2 article2 2}
-	// 1 &{1 article1 1}
+	// Output: 2 {1 article1 1} {2 article2 2}
+	// 1 {1 article1 1}
 }

--- a/example_json_test.go
+++ b/example_json_test.go
@@ -27,14 +27,15 @@ type Item struct {
 	Data jsonMap
 }
 
-type Items []*Item
+type Items struct {
+	C []Item
+}
 
 var _ pg.Collection = &Items{}
 
 func (items *Items) NewRecord() interface{} {
-	i := &Item{}
-	*items = append(*items, i)
-	return i
+	items.C = append(items.C, Item{})
+	return &items.C[len(items.C)-1]
 }
 
 func CreateItem(db *pg.DB, item *Item) error {
@@ -50,12 +51,12 @@ func GetItem(db *pg.DB, id int64) (*Item, error) {
 	return item, err
 }
 
-func GetItems(db *pg.DB) ([]*Item, error) {
+func GetItems(db *pg.DB) ([]Item, error) {
 	var items Items
 	_, err := db.Query(&items, `
 		SELECT * FROM items
 	`)
-	return items, err
+	return items.C, err
 }
 
 func Example_json() {

--- a/exampledb_query_test.go
+++ b/exampledb_query_test.go
@@ -12,14 +12,15 @@ type User struct {
 	Emails []string
 }
 
-type Users []*User
+type Users struct {
+	C []User
+}
 
 var _ pg.Collection = &Users{}
 
 func (users *Users) NewRecord() interface{} {
-	u := &User{}
-	*users = append(*users, u)
-	return u
+	users.C = append(users.C, User{})
+	return &users.C[len(users.C)-1]
 }
 
 func CreateUser(db *pg.DB, user *User) error {
@@ -36,10 +37,10 @@ func GetUser(db *pg.DB, id int64) (*User, error) {
 	return &user, err
 }
 
-func GetUsers(db *pg.DB) ([]*User, error) {
+func GetUsers(db *pg.DB) ([]User, error) {
 	var users Users
 	_, err := db.Query(&users, `SELECT * FROM users`)
-	return users, err
+	return users.C, err
 }
 
 func ExampleDB_Query() {
@@ -81,5 +82,5 @@ func ExampleDB_Query() {
 	fmt.Println(user)
 	fmt.Println(users[0], users[1])
 	// Output: &{1 admin [admin1@admin admin2@admin]}
-	// &{1 admin [admin1@admin admin2@admin]} &{2 root [root1@root root2@root]}
+	// {1 admin [admin1@admin admin2@admin]} {2 root [root1@root root2@root]}
 }


### PR DESCRIPTION
Before:

```
BenchmarkQueryRows	     500	   3277206 ns/op	  923744 B/op	    8034 allocs/op
```

After:

```
BenchmarkQueryRows	     500	   2588617 ns/op	  843561 B/op	    7031 allocs/op
```