### PR TITLE
Don't require users to write collections.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 - postgresql
 
 addons:
-  postgresql: "9.3"
+  postgresql: "9.4"
 
 go:
   - 1.3
@@ -17,11 +17,9 @@ install:
   - go get github.com/golang/glog
   - go get github.com/go-sql-driver/mysql
   - go get github.com/lib/pq
+  - go get github.com/jinzhu/gorm
   - go get gopkg.in/check.v1
   - go get github.com/onsi/ginkgo
   - go get github.com/onsi/gomega
   - mkdir -p $HOME/gopath/src/gopkg.in
   - ln -s `pwd` $HOME/gopath/src/gopkg.in/pg.v3
-
-before_script:
-  - psql -c 'CREATE DATABASE test' -U postgres

--- a/README.md
+++ b/README.md
@@ -113,12 +113,21 @@ func ExampleDB_Query() {
 }
 ```
 
-## Why not database/sql and lib/pq
+## Why not database/sql, lib/pq, or GORM
 
-- On some queries go-pg is 2x faster, because it can load data in 1 client/server round-trip.
-- You don't need to use `rows.Close` to manage connections.
-- go-pg manages memory more efficiently than ORMs for database/sql.
-- Placeholders support allows you to write [complex queries](https://godoc.org/gopkg.in/pg.v3#example-package--ComplexQuery) and stay with SQL.
+- No `rows.Close` to manually manage connections.
+- go-pg can automatically map rows on Go structs.
+- go-pg is at least 3x faster than GORM on querying 100 rows from table.
+- go-pg supports client-side placeholders that allow you to write [complex queries](https://godoc.org/gopkg.in/pg.v3#example-package--ComplexQuery) and have full power of SQL.
+
+## Benchmark
+
+```
+BenchmarkQueryRowsOptimized-4	   10000	    154480 ns/op	   87789 B/op	     624 allocs/op
+BenchmarkQueryRowsReflect-4  	   10000	    196261 ns/op	  102224 B/op	     925 allocs/op
+BenchmarkQueryRowsStdlibPq-4 	    5000	    236584 ns/op	  166528 B/op	    1324 allocs/op
+BenchmarkQueryRowsGORM-4     	    2000	    690532 ns/op	  399661 B/op	    6171 allocs/op
+```
 
 ## Howto
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -7,13 +7,14 @@ import (
 	"testing"
 
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/jinzhu/gorm"
 	_ "github.com/lib/pq"
 
 	"gopkg.in/pg.v3"
 )
 
 func BenchmarkFormatQWithoutArgs(b *testing.B) {
-	rec := &record{
+	rec := &Record{
 		Num1: 1,
 		Num2: 2,
 		Num3: 3,
@@ -34,7 +35,7 @@ func BenchmarkFormatQWithoutArgs(b *testing.B) {
 }
 
 func BenchmarkFormatQWithArgs(b *testing.B) {
-	rec := &record{
+	rec := &Record{
 		Num1: 1,
 		Num2: 2,
 		Num3: 3,
@@ -54,7 +55,7 @@ func BenchmarkFormatQWithArgs(b *testing.B) {
 }
 
 func BenchmarkFormatQWithStructFields(b *testing.B) {
-	rec := &record{
+	rec := &Record{
 		Num1: 1,
 		Num2: 2,
 		Num3: 3,
@@ -74,7 +75,7 @@ func BenchmarkFormatQWithStructFields(b *testing.B) {
 }
 
 func BenchmarkFormatQWithStructMethods(b *testing.B) {
-	rec := &record{
+	rec := &Record{
 		Num1: 1,
 		Num2: 2,
 		Num3: 3,
@@ -94,7 +95,7 @@ func BenchmarkFormatQWithStructMethods(b *testing.B) {
 }
 
 func BenchmarkQueryRows(b *testing.B) {
-	db := pgdb()
+	db := pg.Connect(pgOptions())
 	defer db.Close()
 
 	if err := seedDB(db); err != nil {
@@ -105,26 +106,43 @@ func BenchmarkQueryRows(b *testing.B) {
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			var rs records
-			_, err := db.Query(&rs, `SELECT * FROM bench_test`)
+			var rs Records
+			_, err := db.Query(&rs, `SELECT * FROM records LIMIT 100`)
 			if err != nil {
 				b.Fatal(err)
 			}
-			if len(rs.C) != 1000 {
-				b.Fatalf("got %d, wanted 1000", len(rs.C))
+			if len(rs.C) != 100 {
+				b.Fatalf("got %d, wanted 100", len(rs.C))
 			}
 		}
 	})
 }
 
-func BenchmarkQueryRowsStdlibPq(b *testing.B) {
-	db := pgdb()
+func BenchmarkQueryRowsReflect(b *testing.B) {
+	db := pg.Connect(pgOptions())
 	defer db.Close()
 
 	if err := seedDB(db); err != nil {
 		b.Fatal(err)
 	}
 
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			var rs []Record
+			_, err := db.Query(&rs, `SELECT * FROM records LIMIT 100`)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(rs) != 100 {
+				b.Fatalf("got %d, wanted 100", len(rs))
+			}
+		}
+	})
+}
+
+func BenchmarkQueryRowsStdlibPq(b *testing.B) {
 	pqdb, err := pqdb()
 	if err != nil {
 		b.Fatal(err)
@@ -135,31 +153,54 @@ func BenchmarkQueryRowsStdlibPq(b *testing.B) {
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			rows, err := pqdb.Query(`SELECT * FROM bench_test`)
+			rows, err := pqdb.Query(`SELECT * FROM records LIMIT 100`)
 			if err != nil {
 				b.Fatal(err)
 			}
 
-			var rs []*record
+			var rs []Record
 			for rows.Next() {
-				var rec record
+				rs = append(rs, Record{})
+				rec := &rs[len(rs)-1]
+
 				err := rows.Scan(&rec.Num1, &rec.Num2, &rec.Num3, &rec.Str1, &rec.Str2, &rec.Str3)
 				if err != nil {
 					b.Fatal(err)
 				}
-				rs = append(rs, &rec)
 			}
 			rows.Close()
 
-			if len(rs) != 1000 {
-				b.Fatalf("got %d, wanted 1000", len(rs))
+			if len(rs) != 100 {
+				b.Fatalf("got %d, wanted 100", len(rs))
+			}
+		}
+	})
+}
+
+func BenchmarkQueryRowsGORM(b *testing.B) {
+	db, err := gormdb()
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer db.Close()
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			var rs []Record
+			err := db.Limit(100).Find(&rs).Error
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			if len(rs) != 100 {
+				b.Fatalf("got %d, wanted 100", len(rs))
 			}
 		}
 	})
 }
 
 func BenchmarkQueryRow(b *testing.B) {
-	db := pgdb()
+	db := pg.Connect(pgOptions())
 	defer db.Close()
 
 	b.ResetTimer()
@@ -177,7 +218,7 @@ func BenchmarkQueryRow(b *testing.B) {
 }
 
 func BenchmarkQueryRowStmt(b *testing.B) {
-	db := pgdb()
+	db := pg.Connect(pgOptions())
 	defer db.Close()
 
 	stmt, err := db.Prepare(`SELECT $1::bigint AS num`)
@@ -201,7 +242,7 @@ func BenchmarkQueryRowStmt(b *testing.B) {
 }
 
 func BenchmarkQueryRowLoadInto(b *testing.B) {
-	db := pgdb()
+	db := pg.Connect(pgOptions())
 	defer db.Close()
 
 	b.ResetTimer()
@@ -221,7 +262,7 @@ func BenchmarkQueryRowLoadInto(b *testing.B) {
 }
 
 func BenchmarkQueryRowStmtLoadInto(b *testing.B) {
-	db := pgdb()
+	db := pg.Connect(pgOptions())
 	defer db.Close()
 
 	stmt, err := db.Prepare(`SELECT $1::bigint AS num`)
@@ -338,7 +379,7 @@ func BenchmarkQueryRowStmtStdlibPq(b *testing.B) {
 }
 
 func BenchmarkExec(b *testing.B) {
-	db := pgdb()
+	db := pg.Connect(pgOptions())
 	defer db.Close()
 
 	_, err := db.Exec(
@@ -361,7 +402,7 @@ func BenchmarkExec(b *testing.B) {
 }
 
 func BenchmarkExecWithError(b *testing.B) {
-	db := pgdb()
+	db := pg.Connect(pgOptions())
 	defer db.Close()
 
 	_, err := db.Exec(
@@ -393,7 +434,7 @@ func BenchmarkExecWithError(b *testing.B) {
 }
 
 func BenchmarkExecStmt(b *testing.B) {
-	db := pgdb()
+	db := pg.Connect(pgOptions())
 	defer db.Close()
 
 	_, err := db.Exec(`CREATE TEMP TABLE statement_exec(id bigint, name varchar(500))`)
@@ -455,66 +496,66 @@ func randSeq(n int) string {
 	return string(b)
 }
 
-func pgdb() *pg.DB {
-	return pg.Connect(pgOptions())
-}
-
 func pqdb() (*sql.DB, error) {
-	return sql.Open("postgres", "user=postgres dbname=test")
+	return sql.Open("postgres", "user=postgres dbname=postgres sslmode=disable")
 }
 
 func mysqldb() (*sql.DB, error) {
 	return sql.Open("mysql", "root:root@tcp(localhost:3306)/test")
 }
 
-type record struct {
+func gormdb() (gorm.DB, error) {
+	return gorm.Open("postgres", "user=postgres dbname=postgres sslmode=disable")
+}
+
+type Record struct {
 	Num1, Num2, Num3 int64
 	Str1, Str2, Str3 string
 }
 
-func (r *record) GetNum1() int64 {
+func (r *Record) GetNum1() int64 {
 	return r.Num1
 }
 
-func (r *record) GetNum2() int64 {
+func (r *Record) GetNum2() int64 {
 	return r.Num2
 }
 
-func (r *record) GetNum3() int64 {
+func (r *Record) GetNum3() int64 {
 	return r.Num3
 }
 
-func (r *record) GetStr1() string {
+func (r *Record) GetStr1() string {
 	return r.Str1
 }
 
-func (r *record) GetStr2() string {
+func (r *Record) GetStr2() string {
 	return r.Str2
 }
 
-func (r *record) GetStr3() string {
+func (r *Record) GetStr3() string {
 	return r.Str3
 }
 
-type records struct {
-	C []record
+type Records struct {
+	C []Record
 }
 
-var _ pg.Collection = &records{}
+var _ pg.Collection = &Records{}
 
-func (rs *records) NewRecord() interface{} {
-	rs.C = append(rs.C, record{})
+func (rs *Records) NewRecord() interface{} {
+	rs.C = append(rs.C, Record{})
 	return &rs.C[len(rs.C)-1]
 }
 
 func seedDB(db *pg.DB) error {
-	_, err := db.Exec(`DROP TABLE IF EXISTS bench_test`)
+	_, err := db.Exec(`DROP TABLE IF EXISTS records`)
 	if err != nil {
 		return err
 	}
 
 	_, err = db.Exec(`
-		CREATE TABLE bench_test(
+		CREATE TABLE records(
 			num1 serial,
 			num2 serial,
 			num3 serial,
@@ -529,7 +570,7 @@ func seedDB(db *pg.DB) error {
 
 	for i := 0; i < 1000; i++ {
 		_, err := db.Exec(`
-			INSERT INTO bench_test (str1, str2, str3) VALUES (?, ?, ?)
+			INSERT INTO records (str1, str2, str3) VALUES (?, ?, ?)
 		`, randSeq(100), randSeq(200), randSeq(300))
 		if err != nil {
 			return err

--- a/db.go
+++ b/db.go
@@ -106,7 +106,7 @@ func (opt *Options) getDatabase() string {
 
 func (opt *Options) getPoolSize() int {
 	if opt == nil || opt.PoolSize == 0 {
-		return 5
+		return 10
 	}
 	return opt.PoolSize
 }
@@ -256,7 +256,7 @@ func (db *DB) ExecOne(q string, args ...interface{}) (*Result, error) {
 
 // Query executes a query that returns rows, typically a SELECT. The
 // args are for any placeholder parameters in the query.
-func (db *DB) Query(coll Collection, q string, args ...interface{}) (res *Result, err error) {
+func (db *DB) Query(coll interface{}, q string, args ...interface{}) (res *Result, err error) {
 	backoff := defaultBackoff
 	for i := 0; i < 3; i++ {
 		var cn *conn
@@ -444,7 +444,7 @@ func simpleQuery(cn *conn, q string, args ...interface{}) (*Result, error) {
 	return res, nil
 }
 
-func simpleQueryData(cn *conn, coll Collection, q string, args ...interface{}) (*Result, error) {
+func simpleQueryData(cn *conn, coll interface{}, q string, args ...interface{}) (*Result, error) {
 	if err := writeQueryMsg(cn.buf, q, args...); err != nil {
 		return nil, err
 	}

--- a/example_complexQuery_test.go
+++ b/example_complexQuery_test.go
@@ -32,17 +32,6 @@ type Article struct {
 	CategoryId int
 }
 
-type Articles struct {
-	C []Article
-}
-
-var _ pg.Collection = &Articles{}
-
-func (articles *Articles) NewRecord() interface{} {
-	articles.C = append(articles.C, Article{})
-	return &articles.C[len(articles.C)-1]
-}
-
 func CreateArticle(db *pg.DB, article *Article) error {
 	_, err := db.ExecOne(`
 		INSERT INTO articles (name, category_id)
@@ -58,14 +47,14 @@ func GetArticle(db *pg.DB, id int64) (*Article, error) {
 }
 
 func GetArticles(db *pg.DB, f *ArticleFilter) ([]Article, error) {
-	var articles Articles
+	var articles []Article
 	_, err := db.Query(&articles, `
 		SELECT * FROM articles WHERE 1=1 ?FilterName ?FilterCategory
 	`, f)
 	if err != nil {
 		return nil, err
 	}
-	return articles.C, nil
+	return articles, nil
 }
 
 func Example_complexQuery() {

--- a/example_json_test.go
+++ b/example_json_test.go
@@ -27,36 +27,25 @@ type Item struct {
 	Data jsonMap
 }
 
-type Items struct {
-	C []Item
-}
-
-var _ pg.Collection = &Items{}
-
-func (items *Items) NewRecord() interface{} {
-	items.C = append(items.C, Item{})
-	return &items.C[len(items.C)-1]
-}
-
 func CreateItem(db *pg.DB, item *Item) error {
 	_, err := db.ExecOne(`INSERT INTO items VALUES (?id, ?data)`, item)
 	return err
 }
 
 func GetItem(db *pg.DB, id int64) (*Item, error) {
-	item := &Item{}
-	_, err := db.QueryOne(item, `
+	var item Item
+	_, err := db.QueryOne(&item, `
 		SELECT * FROM items WHERE id = ?
 	`, id)
-	return item, err
+	return &item, err
 }
 
 func GetItems(db *pg.DB) ([]Item, error) {
-	var items Items
+	var items []Item
 	_, err := db.Query(&items, `
 		SELECT * FROM items
 	`)
-	return items.C, err
+	return items, err
 }
 
 func Example_json() {

--- a/exampledb_query_test.go
+++ b/exampledb_query_test.go
@@ -12,20 +12,6 @@ type User struct {
 	Emails []string
 }
 
-// go-pg users collection.
-type Users struct {
-	C []User
-}
-
-// Implements pg.Collection.
-var _ pg.Collection = &Users{}
-
-// NewRecord returns new user and is used by go-pg to load multiple users.
-func (users *Users) NewRecord() interface{} {
-	users.C = append(users.C, User{})
-	return &users.C[len(users.C)-1]
-}
-
 func CreateUser(db *pg.DB, user *User) error {
 	_, err := db.QueryOne(user, `
 		INSERT INTO users (name, emails) VALUES (?name, ?emails)
@@ -41,9 +27,15 @@ func GetUser(db *pg.DB, id int64) (*User, error) {
 }
 
 func GetUsers(db *pg.DB) ([]User, error) {
-	var users Users
+	var users []User
 	_, err := db.Query(&users, `SELECT * FROM users`)
-	return users.C, err
+	return users, err
+}
+
+func GetUsersByIds(db *pg.DB, ids []int64) ([]User, error) {
+	var users []User
+	_, err := db.Query(&users, `SELECT * FROM users WHERE id IN (?)`, pg.Ints(ids))
+	return users, err
 }
 
 func ExampleDB_Query() {

--- a/listener_test.go
+++ b/listener_test.go
@@ -17,11 +17,9 @@ type ListenerTest struct {
 }
 
 func (t *ListenerTest) SetUpTest(c *C) {
-	t.db = pg.Connect(&pg.Options{
-		User:     "postgres",
-		Database: "test",
-		PoolSize: 2,
-	})
+	opt := pgOptions()
+	opt.PoolSize = 2
+	t.db = pg.Connect(opt)
 
 	ln, err := t.db.Listen("test_channel")
 	c.Assert(err, IsNil)

--- a/loader_test.go
+++ b/loader_test.go
@@ -15,10 +15,7 @@ type LoaderTest struct {
 var _ = Suite(&LoaderTest{})
 
 func (t *LoaderTest) SetUpTest(c *C) {
-	t.db = pg.Connect(&pg.Options{
-		User:     "postgres",
-		Database: "test",
-	})
+	t.db = pg.Connect(pgOptions())
 }
 
 func (t *LoaderTest) TearDownTest(c *C) {

--- a/main_test.go
+++ b/main_test.go
@@ -16,10 +16,9 @@ import (
 
 func TestUnixSocket(t *testing.T) {
 	db := pg.Connect(&pg.Options{
-		Network:  "unix",
-		Host:     "/var/run/postgresql/.s.PGSQL.5432",
-		User:     "postgres",
-		Database: "test",
+		Network: "unix",
+		Host:    "/var/run/postgresql/.s.PGSQL.5432",
+		User:    "postgres",
 	})
 	defer db.Close()
 
@@ -38,7 +37,7 @@ type DBTest struct {
 }
 
 func (t *DBTest) SetUpTest(c *C) {
-	t.db = pgdb()
+	t.db = pg.Connect(pgOptions())
 }
 
 func (t *DBTest) TearDownTest(c *C) {

--- a/messages.go
+++ b/messages.go
@@ -441,7 +441,15 @@ func readDataRow(cn *conn, dst interface{}, columns []string) error {
 	return loadErr
 }
 
-func readSimpleQueryData(cn *conn, coll Collection) (res *Result, e error) {
+func readSimpleQueryData(cn *conn, collection interface{}) (res *Result, e error) {
+	coll, ok := collection.(Collection)
+	if !ok {
+		coll, e = newCollection(collection)
+		if e != nil {
+			coll = Discard
+		}
+	}
+
 	var columns []string
 	for {
 		c, msgLen, err := cn.ReadMsgType()
@@ -493,7 +501,15 @@ func readSimpleQueryData(cn *conn, coll Collection) (res *Result, e error) {
 	}
 }
 
-func readExtQueryData(cn *conn, coll Collection, columns []string) (res *Result, e error) {
+func readExtQueryData(cn *conn, collection interface{}, columns []string) (res *Result, e error) {
+	coll, ok := collection.(Collection)
+	if !ok {
+		coll, e = newCollection(collection)
+		if e != nil {
+			coll = Discard
+		}
+	}
+
 	for {
 		c, msgLen, err := cn.ReadMsgType()
 		if err != nil {

--- a/pool_test.go
+++ b/pool_test.go
@@ -14,11 +14,9 @@ import (
 )
 
 func TestCancelRequestOnTimeout(t *testing.T) {
-	db := pg.Connect(&pg.Options{
-		User:        "postgres",
-		Database:    "test",
-		ReadTimeout: time.Second,
-	})
+	opt := pgOptions()
+	opt.ReadTimeout = time.Second
+	db := pg.Connect(opt)
 	defer db.Close()
 
 	_, err := db.Exec("SELECT pg_sleep(60)")
@@ -49,14 +47,11 @@ func TestCancelRequestOnTimeout(t *testing.T) {
 }
 
 func TestStatementTimeout(t *testing.T) {
-	db := pg.Connect(&pg.Options{
-		User:     "postgres",
-		Database: "test",
-
-		Params: map[string]interface{}{
-			"statement_timeout": 1000,
-		},
-	})
+	opt := pgOptions()
+	opt.Params = map[string]interface{}{
+		"statement_timeout": 1000,
+	}
+	db := pg.Connect(opt)
 	defer db.Close()
 
 	_, err := db.Exec("SELECT pg_sleep(60)")
@@ -100,18 +95,14 @@ type PoolTest struct {
 }
 
 func (t *PoolTest) SetUpTest(c *C) {
-	t.db = pg.Connect(&pg.Options{
-		User:     "postgres",
-		Database: "test",
-		PoolSize: 10,
-
-		IdleTimeout:        time.Second,
-		IdleCheckFrequency: time.Second,
-	})
+	opt := pgOptions()
+	opt.IdleTimeout = time.Second
+	opt.IdleCheckFrequency = time.Second
+	t.db = pg.Connect(opt)
 }
 
 func (t *PoolTest) TearDownTest(c *C) {
-	t.db.Close()
+	_ = t.db.Close()
 }
 
 func (t *PoolTest) TestPoolReusesConnection(c *C) {

--- a/stmt.go
+++ b/stmt.go
@@ -102,7 +102,7 @@ func (stmt *Stmt) ExecOne(args ...interface{}) (*Result, error) {
 	return assertOneAffected(res, nil)
 }
 
-func (stmt *Stmt) query(coll Collection, args ...interface{}) (*Result, error) {
+func (stmt *Stmt) query(coll interface{}, args ...interface{}) (*Result, error) {
 	defer stmt.mu.Unlock()
 	stmt.mu.Lock()
 
@@ -114,7 +114,7 @@ func (stmt *Stmt) query(coll Collection, args ...interface{}) (*Result, error) {
 }
 
 // Query executes a prepared query statement with the given arguments.
-func (stmt *Stmt) Query(coll Collection, args ...interface{}) (res *Result, err error) {
+func (stmt *Stmt) Query(coll interface{}, args ...interface{}) (res *Result, err error) {
 	backoff := defaultBackoff
 	for i := 0; i < 3; i++ {
 		res, err = stmt.query(coll, args...)
@@ -167,7 +167,7 @@ func extQuery(cn *conn, name string, args ...interface{}) (*Result, error) {
 	return readExtQuery(cn)
 }
 
-func extQueryData(cn *conn, name string, coll Collection, columns []string, args ...interface{}) (*Result, error) {
+func extQueryData(cn *conn, name string, coll interface{}, columns []string, args ...interface{}) (*Result, error) {
 	if err := writeBindExecuteMsg(cn.buf, name, args...); err != nil {
 		return nil, err
 	}

--- a/tx.go
+++ b/tx.go
@@ -94,7 +94,7 @@ func (tx *Tx) ExecOne(q string, args ...interface{}) (*Result, error) {
 	return assertOneAffected(res, nil)
 }
 
-func (tx *Tx) Query(coll Collection, q string, args ...interface{}) (*Result, error) {
+func (tx *Tx) Query(coll interface{}, q string, args ...interface{}) (*Result, error) {
 	if tx.done {
 		return nil, errTxDone
 	}

--- a/tx_test.go
+++ b/tx_test.go
@@ -13,11 +13,7 @@ type TxTest struct {
 }
 
 func (t *TxTest) SetUpTest(c *C) {
-	t.db = pg.Connect(&pg.Options{
-		User:     "postgres",
-		Database: "test",
-		PoolSize: 10,
-	})
+	t.db = pg.Connect(pgOptions())
 }
 
 func (t *TxTest) TearDownTest(c *C) {

--- a/types_test.go
+++ b/types_test.go
@@ -263,7 +263,7 @@ func TestConversion(t *testing.T) {
 		{src: `{"foo": "bar"}`, dst: new(*JSONField), wanted: JSONField{Foo: "bar"}},
 	}
 
-	db := pgdb()
+	db := pg.Connect(pgOptions())
 	db.Exec("CREATE EXTENSION hstore")
 	defer db.Exec("DROP EXTENSION hstore")
 


### PR DESCRIPTION
New reflect based collections are only slightly slower

```
BenchmarkQueryRows-4                    	   10000	    181824 ns/op	   90989 B/op	     724 allocs/op
BenchmarkQueryRowsReflect-4             	   10000	    199050 ns/op	  102224 B/op	     925 allocs/op
BenchmarkQueryRowsStdlibPq-4            	    5000	    250284 ns/op	  166533 B/op	    1324 allocs/op
BenchmarkQueryRowsGORM-4                	    2000	    705297 ns/op	  399637 B/op	    6171 allocs/op
```