### PR TITLE
Add 1.6 to travis for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
 go:
   - 1.4
   - 1.5
+  - 1.6
   - tip
 
 matrix:


### PR DESCRIPTION
I'm explicitly adding 1.6 since it has been officially released. It would help me specifically know that 1.6 works as expected with this library.