### PR TITLE
User can choice quote of params mapping;

### DIFF
--- a/orm/format.go
+++ b/orm/format.go
@@ -60,7 +60,7 @@ func (f Formatter) append(dst []byte, p *parser.Parser, params []interface{}) []
 		if name := string(p.ReadIdentifier()); name != "" {
 			if f.paramsMap != nil {
 				if param, ok := f.paramsMap[name]; ok {
-					dst = types.Append(dst, param, 1)
+					dst = types.Append(dst, param, 0)
 					continue
 				}
 			}


### PR DESCRIPTION
In some stage, like follow:
```go
TableName string `sql:"star_?SHARD_suffix" json:"-"`
```

will raise db err: `ERROR #42P01 relation "star_'earth'" does not exist`.

and same error with multi-schema:

```go
TableName string `sql:"?shard.users" json:"-"`
```
err: `ERROR #42P01 relation "'shard_9'.users" does not exist`.