### PR TITLE
Remove w.Close() from readCopyData()

### DIFF
--- a/db.go
+++ b/db.go
@@ -205,7 +205,7 @@ func (db *DB) CopyFrom(r io.Reader, query interface{}, params ...interface{}) (*
 }
 
 // CopyTo copies data from a table to writer.
-func (db *DB) CopyTo(w io.WriteCloser, query interface{}, params ...interface{}) (*types.Result, error) {
+func (db *DB) CopyTo(w io.Writer, query interface{}, params ...interface{}) (*types.Result, error) {
 	cn, err := db.conn()
 	if err != nil {
 		return nil, err

--- a/messages.go
+++ b/messages.go
@@ -746,8 +746,7 @@ func readCopyOutResponse(cn *pool.Conn) error {
 	}
 }
 
-func readCopyData(cn *pool.Conn, w io.WriteCloser) (*types.Result, error) {
-	defer w.Close()
+func readCopyData(cn *pool.Conn, w io.Writer) (*types.Result, error) {
 	for {
 		c, msgLen, err := readMessageType(cn)
 		if err != nil {


### PR DESCRIPTION
The call to `w.Close()` prevents `db.CopyTo` from writing multiple dumps to stdout like this:

    db.CopyTo(os.Stdout, 'COPY mytable1 TO STDOUT')
    
    # the following will fail because os.Stdout is closed
    db.CopyTo(os.Stdout, 'COPY mytable2 TO STDOUT')

I'm not sure if there is some reason for the call to Close(), the commit that introduced it does not mention it, so please approach this PR with caution.

Also, I'm new to Golang and this is my first Golang PR, so please bear with me :-).

