### PR TITLE
Release acquired DB connections in db.CopyTo()

### DIFF
--- a/db.go
+++ b/db.go
@@ -232,6 +232,7 @@ func (db *DB) CopyTo(w io.Writer, query interface{}, params ...interface{}) (*ty
 		return nil, err
 	}
 
+	db.pool.Put(cn)
 	return res, nil
 }
 


### PR DESCRIPTION
Otherwise it will program runs out of pool connections and crashes with `pg: connection pool timeout`