### PR TITLE
Add columns cache.

### DIFF
--- a/internal/pool/conn.go
+++ b/internal/pool/conn.go
@@ -12,9 +12,11 @@ var noDeadline = time.Time{}
 
 type Conn struct {
 	NetConn net.Conn
-	Buf     []byte
 	Rd      *bufio.Reader // read buffer
 	Wr      *Buffer       // write buffer
+
+	Buf     []byte   // reusable
+	Columns []string // reusable
 
 	Inited bool
 	UsedAt time.Time


### PR DESCRIPTION
Before

```
BenchmarkQueryRowsGopgDiscard-4   	   20000	     75665 ns/op	     195 B/op	      16 allocs/op
```

After

```
BenchmarkQueryRowsGopgDiscard-4   	   20000	     74377 ns/op	      98 B/op	      15 allocs/op
```

Left allocations are coming from
- ParseInt which requires bytes -> string alloc
- reading columns