### PR TITLE
Add SetParam(string, interface{}) for custom Formater.namedParams

### DIFF
--- a/db.go
+++ b/db.go
@@ -66,6 +66,11 @@ func (db *DB) WithParam(param string, value interface{}) *DB {
 	return &cp
 }
 
+// Allow custom namedParams
+func (db *DB) SetParam(key string, value interface{}) {
+	db.fmter.SetParam(key, value)
+}
+
 func (db *DB) conn() (*pool.Conn, error) {
 	cn, _, err := db.pool.Get()
 	if err != nil {

--- a/tx.go
+++ b/tx.go
@@ -302,3 +302,8 @@ func (tx *Tx) CopyFrom(r io.Reader, query string, params ...interface{}) (*types
 	tx.freeConn(cn, err)
 	return res, err
 }
+
+// Allow custom namedParams
+func (tx *Tx) SetParam(key string, value interface{}) {
+	tx.db.fmter.SetParam(key, value)
+}


### PR DESCRIPTION
I have many alike tables in database schema, and they need transaction when operated them, like:
```sql
CREATE TABLE  alias_email (LIKE alias_ INCLUDING ALL);
CREATE TABLE  alias_mobile (LIKE alias_ INCLUDING ALL);
CREATE TABLE  alias_credit (LIKE alias_ INCLUDING ALL);
CREATE TABLE  alias_idcard (LIKE alias_ INCLUDING ALL);

CREATE TABLE device_android(LIKE device INCLUDING ALL, CHECK(cate_id = 1));
CREATE TABLE device_ios(LIKE device INCLUDING ALL, CHECK(cate_id = 2));

```
code sample
```go
type Alias struct {
	TableName string `sql:"alias_?SHARDA" json:"-"`
}

type Device struct {
	TableName string `sql:"device_?SHARDD" json:"-"`
}
```