### PR TITLE
orm: ignore tableName of embedded struct.

### DIFF
--- a/orm/insert_test.go
+++ b/orm/insert_test.go
@@ -7,9 +7,17 @@ import (
 
 type InsertTest struct{}
 
+type EmbeddingTest struct {
+	tableName struct{} `sql:"name"`
+}
+
 type EmbeddedInsertTest struct {
 	tableName struct{} `sql:"my_name"`
-	InsertTest
+	EmbeddingTest
+}
+
+type OverrideInsertTest struct {
+	EmbeddingTest `pg:",override"`
 }
 
 var _ = Describe("Insert", func() {
@@ -41,5 +49,13 @@ var _ = Describe("Insert", func() {
 		b, err := insertQuery{Query: q}.AppendQuery(nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(b)).To(Equal(`INSERT INTO my_name () VALUES ()`))
+	})
+
+	It("supports override table name with embedded struct", func() {
+		q := NewQuery(nil, &OverrideInsertTest{})
+
+		b, err := insertQuery{Query: q}.AppendQuery(nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(b)).To(Equal(`INSERT INTO name () VALUES ()`))
 	})
 })

--- a/orm/table.go
+++ b/orm/table.go
@@ -213,6 +213,9 @@ func (t *Table) newField(f reflect.StructField, index []int) *Field {
 
 	switch f.Name {
 	case "tableName", "TableName":
+		if index != nil {
+			return nil
+		}
 		if sqlName != "" {
 			t.Name = types.Q(sqlName)
 		}


### PR DESCRIPTION
Fixes https://github.com/go-pg/pg/issues/432