### PR TITLE
Custom error logger and query logger

### DIFF
--- a/internal/log.go
+++ b/internal/log.go
@@ -2,16 +2,23 @@ package internal
 
 import (
 	"fmt"
-	"log"
 	"path/filepath"
 	"runtime"
 	"strings"
 )
 
 var (
-	Logger      *log.Logger
-	QueryLogger *log.Logger
+	Logger      IErrorLogger
+	QueryLogger IQueryLogger
 )
+
+type IErrorLogger interface {
+	Output(calldepth int, s string) error
+}
+
+type IQueryLogger interface {
+	Printf(format string, v ...interface{})
+}
 
 func Logf(s string, args ...interface{}) {
 	if Logger == nil {

--- a/pg.go
+++ b/pg.go
@@ -1,7 +1,6 @@
 package pg // import "gopkg.in/pg.v5"
 
 import (
-	"log"
 	"strconv"
 
 	"gopkg.in/pg.v5/internal"
@@ -63,12 +62,12 @@ func Hstore(v interface{}) *types.Hstore {
 	return types.NewHstore(v)
 }
 
-func SetLogger(logger *log.Logger) {
+func SetLogger(logger internal.IErrorLogger) {
 	internal.Logger = logger
 }
 
 // SetQueryLogger sets a logger that will be used to log generated queries.
-func SetQueryLogger(logger *log.Logger) {
+func SetQueryLogger(logger internal.IQueryLogger) {
 	internal.QueryLogger = logger
 }
 


### PR DESCRIPTION
Use interface instead of `*log.Logger`, remove dependency of go `log`