### PR TITLE
InsecureSkipVerify and default database user name

### DIFF
--- a/options.go
+++ b/options.go
@@ -154,14 +154,14 @@ func ParseURL(sURL string) (*Options, error) {
 		case "allow":
 			fallthrough
 		case "prefer":
-			options.TLSConfig = &tls.Config{}
+			options.TLSConfig = &tls.Config{InsecureSkipVerify: true}
 		case "disable":
 			options.TLSConfig = nil
 		default:
 			return nil, errors.New(fmt.Sprintf("pg: sslmode '%v' is not supported", sslMode[0]))
 		}
 	} else {
-		options.TLSConfig = &tls.Config{}
+		options.TLSConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 
 	delete(query, "sslmode")

--- a/options.go
+++ b/options.go
@@ -136,6 +136,10 @@ func ParseURL(sURL string) (*Options, error) {
 		}
 	}
 
+	if options.User == "" {
+		options.User = "postgres"
+	}
+
 	// database
 	if len(strings.Trim(parsedUrl.Path, "/")) > 0 {
 		options.Database = parsedUrl.Path[1:]

--- a/options_test.go
+++ b/options_test.go
@@ -119,7 +119,7 @@ func TestParseURL(t *testing.T) {
 		{
 			"postgres://somewhere.at.amazonaws.com:5432/postgres",
 			"somewhere.at.amazonaws.com:5432",
-			"",
+			"postgres",
 			"",
 			"postgres",
 			true,
@@ -128,7 +128,7 @@ func TestParseURL(t *testing.T) {
 		{
 			"http://google.com/test",
 			"google.com:5432",
-			"",
+			"postgres",
 			"",
 			"test",
 			true,
@@ -145,7 +145,7 @@ func TestParseURL(t *testing.T) {
 			}
 			if c.err != nil && err != nil {
 				if c.err.Error() != err.Error() {
-					t.Fatalf("got %q, want %q", err, c.err)
+					t.Fatalf("expected error %q, want %q", err, c.err)
 				}
 				return
 			}
@@ -153,16 +153,16 @@ func TestParseURL(t *testing.T) {
 				t.Errorf("expected error %q, got nothing", c.err)
 			}
 			if o.Addr != c.addr {
-				t.Errorf("got %q, want %q", o.Addr, c.addr)
+				t.Errorf("addr: got %q, want %q", o.Addr, c.addr)
 			}
 			if o.User != c.user {
-				t.Errorf("got %q, want %q", o.User, c.user)
+				t.Errorf("user: got %q, want %q", o.User, c.user)
 			}
 			if o.Password != c.password {
-				t.Errorf("got %q, want %q", o.Password, c.password)
+				t.Errorf("password: got %q, want %q", o.Password, c.password)
 			}
 			if o.Database != c.database {
-				t.Errorf("got %q, want %q", o.Database, c.database)
+				t.Errorf("database: got %q, want %q", o.Database, c.database)
 			}
 
 			if c.tls {

--- a/options_test.go
+++ b/options_test.go
@@ -164,8 +164,13 @@ func TestParseURL(t *testing.T) {
 			if o.Database != c.database {
 				t.Errorf("got %q, want %q", o.Database, c.database)
 			}
-			if o.TLSConfig == nil && c.tls {
-				t.Error("got nil TLSConfig, expected a TLSConfig")
+
+			if c.tls {
+				if o.TLSConfig == nil {
+					t.Error("got nil TLSConfig, expected a TLSConfig")
+				} else if !o.TLSConfig.InsecureSkipVerify {
+					t.Error("must set InsecureSkipVerify to true in TLSConfig, got false")
+				}
 			}
 		})
 	}


### PR DESCRIPTION
To make `ParseURL` working in Heroku I've changed default TLSConfig created when parsing database URL to have `InsecureSkipVerify=true` . This is a minimum for this to work in Heroku.

I've also set default database user name to 'postgres' because otherwise Postgres is throwing an error (not a case for Heroku but good to have).