### PR TITLE
Fix/order by nulls first

### DIFF
--- a/orm/query.go
+++ b/orm/query.go
@@ -238,12 +238,12 @@ func (q *Query) Having(having string, params ...interface{}) *Query {
 func (q *Query) Order(orders ...string) *Query {
 loop:
 	for _, order := range orders {
-		ind := strings.LastIndex(order, " ")
+		ind := strings.Index(order, " ")
 		if ind != -1 {
 			field := order[:ind]
 			sort := order[ind+1:]
 			switch internal.ToUpper(sort) {
-			case "ASC", "DESC":
+			case "ASC", "DESC", "ASC NULLS FIRST", "DESC NULLS FIRST":
 				q.order = append(q.order, queryParamsAppender{
 					query:  "? ?",
 					params: []interface{}{types.F(field), types.Q(sort)},

--- a/orm/query.go
+++ b/orm/query.go
@@ -243,7 +243,8 @@ loop:
 			field := order[:ind]
 			sort := order[ind+1:]
 			switch internal.ToUpper(sort) {
-			case "ASC", "DESC", "ASC NULLS FIRST", "DESC NULLS FIRST":
+			case "ASC", "DESC", "ASC NULLS FIRST", "DESC NULLS FIRST",
+				"ASC NULLS LAST", "DESC NULLS LAST":
 				q.order = append(q.order, queryParamsAppender{
 					query:  "? ?",
 					params: []interface{}{types.F(field), types.Q(sort)},

--- a/orm/select_test.go
+++ b/orm/select_test.go
@@ -187,7 +187,7 @@ var _ = Describe("Select Order", func() {
 		{"id desc", `"id" desc`},
 		{"id ASC", `"id" ASC`},
 		{"id DESC", `"id" DESC`},
-		{"id ASC NULLS FIRST", `"id ASC NULLS FIRST"`},
+		{"id ASC NULLS FIRST", `"id" ASC NULLS FIRST`},
 	}
 
 	It("sets order", func() {


### PR DESCRIPTION
When using PostgreSQL 'NULLS FIRST' order modifier, it should take only the column name in quotes:

`"column_name" DESC NULLS FIRST`
, not all the ORDER BY expression as it was before:

`"column_name DESC NULLS FIRST"`

test fixed accordingly