### PR TITLE
fix(documentation): PoolTimeout default value is incorrect

### DIFF
--- a/options.go
+++ b/options.go
@@ -63,7 +63,7 @@ type Options struct {
 	PoolSize int
 	// Time for which client waits for free connection if all
 	// connections are busy before returning an error.
-	// Default is 5 seconds.
+	// Default is 30 seconds if ReadTimeOut is not defined, otherwise, ReadTimeout + 1 second.
 	PoolTimeout time.Duration
 	// Time after which client closes idle connections.
 	// Default is to not close idle connections.


### PR DESCRIPTION
Signed-off-by: Romain Beuque <romain.beuque@corp.ovh.com>