### PR TITLE
parser: don't allow identifiers to start with underscore

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -88,14 +88,14 @@ func (p *Parser) ReadIdentifier() (s string, numeric bool) {
 		if isNum(ch) {
 			continue
 		}
-		if isAlpha(ch) || ch == '_' {
+		if isAlpha(ch) || (i > 0 && ch == '_') {
 			numeric = false
 			continue
 		}
 		end = i
 		break
 	}
-	if end <= 0 {
+	if end == 0 {
 		return "", false
 	}
 	b := p.b[:end]

--- a/orm/format_test.go
+++ b/orm/format_test.go
@@ -71,6 +71,7 @@ var formatTests = []formatTest{
 	{q: "?", params: params{ValuerError("error")}, wanted: "?!(error)"},
 
 	{q: "?", wanted: "?"},
+	{q: "?_?", params: params{"foo", "bar"}, wanted: "'foo'_'bar'"},
 	{q: "? ? ?", params: params{"foo", "bar"}, wanted: "'foo' 'bar' ?"},
 	{q: "?0 ?1", params: params{"foo", "bar"}, wanted: "'foo' 'bar'"},
 	{q: "?0 ?1 ?2", params: params{"foo", "bar"}, wanted: "'foo' 'bar' ?2"},


### PR DESCRIPTION
Fixes https://github.com/go-pg/pg/issues/745