### PR TITLE
orm: consolidate isPostgresKeyword

### DIFF
--- a/orm/table.go
+++ b/orm/table.go
@@ -498,10 +498,11 @@ func (t *Table) newField(f reflect.StructField, index []int) *Field {
 
 func isPostgresKeyword(s string) bool {
 	switch s {
-	case "user":
+	case "user", "group", "constraint", "limit", "member", "placing", "references", "table":
 		return true
+	default:
+		return false
 	}
-	return false
 }
 
 func isColumn(typ reflect.Type) bool {

--- a/orm/table.go
+++ b/orm/table.go
@@ -497,7 +497,7 @@ func (t *Table) newField(f reflect.StructField, index []int) *Field {
 }
 
 func isPostgresKeyword(s string) bool {
-	switch s {
+	switch strings.ToLower(s) {
 	case "user", "group", "constraint", "limit", "member", "placing", "references", "table":
 		return true
 	default:


### PR DESCRIPTION
I encountered an issue with a table called `group` which triggered a syntax error from postgres (related to https://github.com/go-pg/pg/issues/496) as `GROUP` is a reserved keyword.

To fix that I checked the list of reserved keyword from [Postgres Documentation](https://www.postgresql.org/docs/current/static/sql-keywords-appendix.html) and added what would be possible table name to the check.

I also added a `strings.ToLower` call to the checked word as the check did not cover the case where a table is called `User` which can happen with database created by some previous ORM or a user.