### PR TITLE
Omit zero value on notnull fields with default value

### DIFF
--- a/orm/field.go
+++ b/orm/field.go
@@ -71,16 +71,8 @@ func (f *Field) IsZero(strct reflect.Value) bool {
 }
 
 func (f *Field) OmitZero(strct reflect.Value) bool {
-	return !f.HasFlag(NotNullFlag) && f.isZero(f.Value(strct))
-}
-
-// InsertDefault returns whether this field should be set to DEFAULT
-// when inserting strct.
-// This is the case if either the field is nullable and has its zero value
-// or the field is not nullable and the value is a nil pointer.
-func (f *Field) InsertDefault(strct reflect.Value) bool {
 	val := f.Value(strct)
-	return f.OmitZero(strct) ||
+	return (!f.HasFlag(NotNullFlag) && f.isZero(val)) ||
 		(f.HasFlag(NotNullFlag) && val.Kind() == reflect.Ptr && val.IsNil())
 }
 

--- a/orm/field.go
+++ b/orm/field.go
@@ -74,6 +74,16 @@ func (f *Field) OmitZero(strct reflect.Value) bool {
 	return !f.HasFlag(NotNullFlag) && f.isZero(f.Value(strct))
 }
 
+// InsertDefault returns whether this field should be set to DEFAULT
+// when inserting strct.
+// This is the case if either the field is nullable and has its zero value
+// or the field is not nullable and the value is a nil pointer.
+func (f *Field) InsertDefault(strct reflect.Value) bool {
+	val := f.Value(strct)
+	return f.OmitZero(strct) ||
+		(f.HasFlag(NotNullFlag) && val.Kind() == reflect.Ptr && val.IsNil())
+}
+
 func (f *Field) AppendValue(b []byte, strct reflect.Value, quote int) []byte {
 	fv := f.Value(strct)
 	if !f.HasFlag(NotNullFlag) && f.isZero(fv) {

--- a/orm/field.go
+++ b/orm/field.go
@@ -71,9 +71,7 @@ func (f *Field) IsZero(strct reflect.Value) bool {
 }
 
 func (f *Field) OmitZero(strct reflect.Value) bool {
-	val := f.Value(strct)
-	return (!f.HasFlag(NotNullFlag) && f.isZero(val)) ||
-		(f.HasFlag(NotNullFlag) && val.Kind() == reflect.Ptr && val.IsNil())
+	return (f.Default != "" || !f.HasFlag(NotNullFlag)) && f.isZero(f.Value(strct))
 }
 
 func (f *Field) AppendValue(b []byte, strct reflect.Value, quote int) []byte {

--- a/orm/insert.go
+++ b/orm/insert.go
@@ -131,7 +131,7 @@ func (q *insertQuery) appendValues(b []byte, fields []*Field, v reflect.Value) [
 			continue
 		}
 
-		if f.OmitZero(v) {
+		if f.InsertDefault(v) {
 			b = append(b, "DEFAULT"...)
 			q.addReturningField(f)
 		} else {

--- a/orm/insert.go
+++ b/orm/insert.go
@@ -131,7 +131,7 @@ func (q *insertQuery) appendValues(b []byte, fields []*Field, v reflect.Value) [
 			continue
 		}
 
-		if f.InsertDefault(v) {
+		if f.OmitZero(v) {
 			b = append(b, "DEFAULT"...)
 			q.addReturningField(f)
 		} else {


### PR DESCRIPTION
Currently, it is not possible to create `NOT NULL` columns with `DEFAULT` values using `go-pg`,
because the `notnull` option causes zero values which otherwise represent `NULL` to be inserted in the database:

```go
type A struct {
	Id   int64
	Time time.Time `sql:",notnull,default:NOW()"`
}

func main() {
	// [... database initialization ...]
	a := &A{}
	if err := db.Insert(a); err != nil {
		panic(err)
	}
	log.Printf("%d %s\n", a.Id, a.Time)
	// outputs: 1 0001-01-01 00:00:00 +0000 UTC
}
```

To let `go-pg` determine whether the zero value should be inserted or `DEFAULT` should be used, we can use **pointer types**:
```go
type B struct {
	Id   int64
	Time *time.Time `sql:",notnull,default:NOW()"`
}

func main() {
	// [... database initialization ...]
	b := &B{}
	if err := db.Insert(b); err != nil {
		panic(err)
	}
	log.Printf("%d %s\n", b.Id, b.Time)
	// outputs: 1 2018-03-12 10:32:26.092161 +0000 +0000
}
```

If `notnull` is set for a field, but the value is a `nil` pointer, `DEFAULT` is used when inserting.