### PR TITLE
update options URI scheme

### DIFF
--- a/options.go
+++ b/options.go
@@ -134,7 +134,7 @@ func ParseURL(sURL string) (*Options, error) {
 	}
 
 	// scheme
-	if parsedUrl.Scheme != "postgres" {
+	if parsedUrl.Scheme != "postgres" || parsedUrl.Scheme != "postgresql" {
 		return nil, errors.New("pg: invalid scheme: " + parsedUrl.Scheme)
 	}
 


### PR DESCRIPTION
The URI scheme designator can be either postgresql:// or postgres://. Each of the URI parts is optional. The following examples illustrate valid URI syntax uses: