### PR TITLE
Accept postgresql as scheme.

### DIFF
--- a/options.go
+++ b/options.go
@@ -134,7 +134,7 @@ func ParseURL(sURL string) (*Options, error) {
 	}
 
 	// scheme
-	if parsedUrl.Scheme != "postgres" {
+	if parsedUrl.Scheme != "postgres" && parsedUrl.Scheme != "postgresql" {
 		return nil, errors.New("pg: invalid scheme: " + parsedUrl.Scheme)
 	}
 

--- a/options_test.go
+++ b/options_test.go
@@ -126,6 +126,15 @@ func TestParseURL(t *testing.T) {
 			nil,
 		},
 		{
+			"postgresql://somewhere.at.amazonaws.com:5432/postgres",
+			"somewhere.at.amazonaws.com:5432",
+			"postgres",
+			"",
+			"postgres",
+			true,
+			nil,
+		},
+		{
 			"http://google.com/test",
 			"google.com:5432",
 			"postgres",


### PR DESCRIPTION
This commit updates the options.go file to accept postgresql as a
scheme.

As per the postgresql docs the scheme can either be postgres:// or
postgresql://

    The general form for a connection URI is:
    postgresql://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]
    The URI scheme designator can be either postgresql:// or postgres://. Each of the URI parts is optional.

It also updates a the test to include this additional option