### PR TITLE
fix soft delete when deleted_at column is mapped to *time.Time

### DIFF
--- a/orm/model_table_struct.go
+++ b/orm/model_table_struct.go
@@ -346,7 +346,12 @@ func (m *structTableModel) join(
 func (m *structTableModel) setDeletedAt() {
 	field := m.table.FieldsMap["deleted_at"]
 	value := field.Value(m.strct)
-	value.Set(reflect.ValueOf(time.Now()))
+	if value.Kind() == reflect.Ptr {
+		now := time.Now()
+		value.Set(reflect.ValueOf(&now))
+	} else {
+		value.Set(reflect.ValueOf(time.Now()))
+	}
 }
 
 func splitColumn(s string) (string, string) {


### PR DESCRIPTION
Soft delete fails when `deleted_at` column is mapped to a struct field of type `*time.Time`
`Panic: reflect.Set: value of type time.Time is not assignable to type *time.Time`