### PR TITLE
Grpc timestamp

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/go-pg/pg
 
 require (
+	github.com/golang/protobuf v1.2.0
 	github.com/jinzhu/inflection v0.0.0-20180308033659-04140366298a
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/onsi/ginkgo v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=

--- a/types/append.go
+++ b/types/append.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"strconv"
 	"time"
+
+	tspb "github.com/golang/protobuf/ptypes/timestamp"
 )
 
 func Append(b []byte, v interface{}, quote int) []byte {
@@ -43,6 +45,8 @@ func Append(b []byte, v interface{}, quote int) []byte {
 		return AppendString(b, v, quote)
 	case time.Time:
 		return AppendTime(b, v, quote)
+	case tspb.Timestamp:
+		return AppendGrpcTime(b, v, quote)
 	case []byte:
 		return AppendBytes(b, v, quote)
 	case ValueAppender:

--- a/types/append_value.go
+++ b/types/append_value.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-pg/pg/internal"
+	tspb "github.com/golang/protobuf/ptypes/timestamp"
 )
 
 var driverValuerType = reflect.TypeOf((*driver.Valuer)(nil)).Elem()
@@ -57,6 +58,8 @@ func appender(typ reflect.Type, pgArray bool) AppenderFunc {
 	switch typ {
 	case timeType:
 		return appendTimeValue
+	case grpcTimeType:
+		return appendGrpcTimeValue
 	case ipType:
 		return appendIPValue
 	case ipNetType:
@@ -160,6 +163,11 @@ func appendJSONValue(b []byte, v reflect.Value, quote int) []byte {
 func appendTimeValue(b []byte, v reflect.Value, quote int) []byte {
 	tm := v.Interface().(time.Time)
 	return AppendTime(b, tm, quote)
+}
+
+func appendGrpcTimeValue(b []byte, v reflect.Value, quote int) []byte {
+	tm := v.Interface().(tspb.Timestamp)
+	return AppendGrpcTime(b, tm, quote)
 }
 
 func appendIPValue(b []byte, v reflect.Value, quote int) []byte {

--- a/types/time.go
+++ b/types/time.go
@@ -4,6 +4,9 @@ import (
 	"time"
 
 	"github.com/go-pg/pg/internal"
+
+	"github.com/golang/protobuf/ptypes"
+	tspb "github.com/golang/protobuf/ptypes/timestamp"
 )
 
 const (
@@ -47,6 +50,21 @@ func ParseTimeString(s string) (time.Time, error) {
 func AppendTime(b []byte, tm time.Time, quote int) []byte {
 	if quote == 1 {
 		b = append(b, '\'')
+	}
+	b = tm.UTC().AppendFormat(b, timestamptzFormat)
+	if quote == 1 {
+		b = append(b, '\'')
+	}
+	return b
+}
+
+func AppendGrpcTime(b []byte, ts tspb.Timestamp, quote int) []byte {
+	if quote == 1 {
+		b = append(b, '\'')
+	}
+	tm, err := ptypes.Timestamp(&ts)
+	if err != nil {
+		return nil
 	}
 	b = tm.UTC().AppendFormat(b, timestamptzFormat)
 	if quote == 1 {


### PR DESCRIPTION
Hi,

My name is Bogdan Utanu, I work at [Gomedia](https://gomedia.io). We use GRPC but we noticed `go-pg` has no support for the [Protobuf Timestamp type](https://github.com/golang/protobuf/blob/master/ptypes/timestamp.go) 

We think it would be very handy to be able to use the same structs generated from GRPC with `go-pg`, and this would constitute a nice feature of `go-pg`.

These changes are based on [a previous PR](https://github.com/go-pg/pg/compare/master...abronan:grpc_timestamp_support).