### PR TITLE
Added support for tablespaces in models.

### DIFF
--- a/orm/table.go
+++ b/orm/table.go
@@ -52,6 +52,8 @@ type Table struct {
 	FullName           types.Q
 	FullNameForSelects types.Q
 
+	Tablespace types.Q
+
 	allFields     []*Field // read only
 	skippedFields []*Field
 
@@ -75,6 +77,10 @@ func (t *Table) setName(name types.Q) {
 	if t.Alias == "" {
 		t.Alias = name
 	}
+}
+
+func (t *Table) setTableSpace(name types.Q) {
+	t.Tablespace = name
 }
 
 func newTable(typ reflect.Type) *Table {
@@ -261,6 +267,16 @@ func (t *Table) newField(f reflect.StructField, index []int) *Field {
 	case "tableName", "TableName":
 		if len(index) > 0 {
 			return nil
+		}
+
+		tableSpace, ok := sqlTag.Options["tablespace"]
+		if ok {
+			if tableSpace == "_" {
+				t.setTableSpace("")
+			} else if tableSpace != "" {
+				s, _ := tag.Unquote(tableSpace)
+				t.setTableSpace(types.Q(fmt.Sprintf(`"%s"`, s)))
+			}
 		}
 
 		if sqlTag.Name == "_" {

--- a/orm/table_create.go
+++ b/orm/table_create.go
@@ -1,6 +1,7 @@
 package orm
 
 import (
+	"github.com/go-pg/pg/types"
 	"strconv"
 )
 
@@ -102,6 +103,10 @@ func (q *createTableQuery) AppendQuery(b []byte) ([]byte, error) {
 
 	b = append(b, ")"...)
 
+	if table.Tablespace != "" {
+		b = q.appendTablespace(b, table.Tablespace)
+	}
+
 	return b, q.q.stickyErr
 }
 
@@ -148,6 +153,12 @@ func (q createTableQuery) appendFKConstraint(b []byte, table *Table, rel *Relati
 		b = append(b, s...)
 	}
 
+	return b
+}
+
+func (q createTableQuery) appendTablespace(b []byte, tableSpace types.Q) []byte {
+	b = append(b, " TABLESPACE "...)
+	b = append(b, tableSpace...)
 	return b
 }
 

--- a/orm/table_create_test.go
+++ b/orm/table_create_test.go
@@ -54,6 +54,12 @@ type CreateTableOnDeleteOnUpdateModel struct {
 	CreateTableModel   *CreateTableModel
 }
 
+type CreateTableWithTablespace struct {
+	tableName string `sql:"tablespace:ssd"`
+
+	String string
+}
+
 var _ = Describe("CreateTable", func() {
 	It("creates new table", func() {
 		q := NewQuery(nil, &CreateTableModel{})
@@ -87,5 +93,14 @@ var _ = Describe("CreateTable", func() {
 		b, err := (&createTableQuery{q: q, opt: opt}).AppendQuery(nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(b)).To(Equal(`CREATE TABLE "create_table_on_delete_on_update_models" ("id" bigserial, "create_table_model_id" bigint, PRIMARY KEY ("id"), FOREIGN KEY ("create_table_model_id") REFERENCES "create_table_models" ("id") ON DELETE RESTRICT ON UPDATE CASCADE)`))
+	})
+
+	It("creates new table with tablespace options", func() {
+		q := NewQuery(nil, &CreateTableWithTablespace{})
+
+		opt := &CreateTableOptions{}
+		b, err := (&createTableQuery{q: q, opt: opt}).AppendQuery(nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(b)).To(Equal(`CREATE TABLE "create_table_with_tablespaces" ("string" text) TABLESPACE "ssd"`))
 	})
 })


### PR DESCRIPTION
This will allow a `tableSpace` string field to be added to a struct and will take the value of the name in the SQL tag and set the table space when creating a table.

https://www.postgresql.org/docs/current/manage-ag-tablespaces.html

I've made it so that it will also quote the tablespace names just to be safe (to be consistent with quoting table names).

I would love feedback!