### PR TITLE
Pass context down CountEstimate queries.

### DIFF
--- a/orm/count_estimate.go
+++ b/orm/count_estimate.go
@@ -58,7 +58,8 @@ func (q *Query) CountEstimate(threshold int) (int, error) {
 
 	for i := 0; i < 3; i++ {
 		var count int
-		_, err = q.db.QueryOne(
+		_, err = q.db.QueryOneContext(
+			q.ctx,
 			Scan(&count),
 			"SELECT _go_pg_count_estimate_v2(?, ?)",
 			string(query), threshold,
@@ -83,6 +84,6 @@ func (q *Query) CountEstimate(threshold int) (int, error) {
 }
 
 func (q *Query) createCountEstimateFunc() error {
-	_, err := q.db.Exec(pgCountEstimateFunc)
+	_, err := q.db.ExecContext(q.ctx, pgCountEstimateFunc)
 	return err
 }


### PR DESCRIPTION
This allows context to be passed into the after hooks.