### PR TITLE
Added support for unique partial indexes.

### DIFF
--- a/internal/util.go
+++ b/internal/util.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"reflect"
 	"strings"
+	"unicode"
 )
 
 func MakeSliceNextElemFunc(v reflect.Value) func() reflect.Value {
@@ -48,7 +49,9 @@ func MakeSliceNextElemFunc(v reflect.Value) func() reflect.Value {
 }
 
 func QuoteTableName(s string) string {
-	if isPostgresKeyword(s) {
+	// The IsDigit will save names if they begin with a number.
+	// PostgreSQL doesn't allow a normal name to begin with a number, but if it's quoted it works.
+	if isPostgresKeyword(s) || unicode.IsDigit(rune(s[0])) {
 		return `"` + s + `"`
 	}
 	return s


### PR DESCRIPTION
This adds support for unique partial indexes. Something I was trying to achieve when working on a project. 

At the moment this only adds support for uniques, but if you feel the need I'd be happy to add support for partial indexes in general.

This also makes it so that multiple unique constraints can be named on a field.
Example:
```golang
ProductName string `sql:"product_name,unique:'per_user,per_account'"`
```

Here is some documentation on partial indexes.
https://www.postgresql.org/docs/current/indexes-partial.html


The partial indexes can be used like this:

```golang
type Inventory struct {
	tableName   string `sql:"inventory"`
	uniqueWhere string `sql:"per_account:'asset_id IS NOT NULL',without_asset:'asset_id IS NULL'"`

	InventoryID uint64     `json:"inventoryId" sql:"inventory_id,pk,type:'bigserial'"`
	AccountID   uint64     `json:"-" sql:"account_id,notnull,on_delete:RESTRICT,unique:'per_account,without_asset'" field:"accountId"`
	Account     *Account   `json:"-"`
	BinID       uint64     `json:"binId,omitempty" sql:"bin_id,unique:'per_account,without_asset'"`
	Bin         *Bin       `json:"bin,omitempty"`
	VariationID uint64     `json:"variationId" sql:"variation_id,notnull,unique:'per_account,without_asset'"`
	Variation   *Variation `json:"variation,omitempty"`
	AssetID     *uint64    `json:"assetId,omitempty" sql:"asset_id,null,unique:per_account,on_delete:RESTRICT"`
	Asset       *Asset     `json:"asset,omitempty"`
	QTY         float64    `json:"qty" sql:"qty"`
}
```

This would basically make it so that the rows would need to have unique values of AccountID, BinID, VariationID and null AssetID or if AssetID was not null then it must also be unique with those rows.

Essentially generating this query.

```sql
CREATE TABLE inventory (
  "inventory_id"  bigserial,
  "bin_id"        bigint,
  "variation_id"  bigint    NOT NULL,
  "asset_id"      bigint,
  "qty"           double precision,
  "account_id"    bigint    NOT NULL,
  PRIMARY KEY ("inventory_id"),
  FOREIGN KEY ("bin_id") REFERENCES bins ("bin_id"),
  FOREIGN KEY ("variation_id") REFERENCES variations ("variation_id"),
  FOREIGN KEY ("asset_id") REFERENCES assets ("asset_id") ON DELETE RESTRICT,
  FOREIGN KEY ("account_id") REFERENCES accounts ("account_id") ON DELETE RESTRICT
);
CREATE UNIQUE INDEX per_account
  ON "inventory" ("bin_id", "variation_id", "asset_id", "account_id")
  WHERE asset_id IS NOT NULL;
CREATE UNIQUE INDEX without_asset
  ON "inventory" ("bin_id", "variation_id", "account_id")
  WHERE asset_id IS NULL;
```