### PR TITLE
Allow for has many queries to be executed in a single round trip.

### DIFF
--- a/orm/join.go
+++ b/orm/join.go
@@ -199,7 +199,7 @@ func appendAlias(b []byte, j *join, topLevel bool) []byte {
 	return b
 }
 
-func (j *join) appendHasOneColumns(b []byte) []byte {
+func (j *join) appendHasOneColumns(b []byte, excludeAlias bool) []byte {
 	if j.Columns == nil {
 		for i, f := range j.JoinModel.Table().Fields {
 			if i > 0 {
@@ -208,8 +208,10 @@ func (j *join) appendHasOneColumns(b []byte) []byte {
 			b = j.appendAlias(b)
 			b = append(b, '.')
 			b = append(b, f.Column...)
-			b = append(b, " AS "...)
-			b = j.appendAliasColumn(b, f.SQLName)
+			if !excludeAlias {
+				b = append(b, " AS "...)
+				b = j.appendAliasColumn(b, f.SQLName)
+			}
 		}
 		return b
 	}
@@ -221,8 +223,10 @@ func (j *join) appendHasOneColumns(b []byte) []byte {
 		b = j.appendAlias(b)
 		b = append(b, '.')
 		b = types.AppendField(b, column, 1)
-		b = append(b, " AS "...)
-		b = j.appendAliasColumn(b, column)
+		if !excludeAlias {
+			b = append(b, " AS "...)
+			b = j.appendAliasColumn(b, column)
+		}
 	}
 
 	return b

--- a/orm/query.go
+++ b/orm/query.go
@@ -820,6 +820,13 @@ func (q *Query) forEachHasOneJoin(fn func(*join)) {
 	q._forEachHasOneJoin(fn, q.model.GetJoins())
 }
 
+func (q *Query) forEachHasManyJoin(fn func(*join)) {
+	if q.model == nil {
+		return
+	}
+	q._forEachHasManyJoin(fn, q.model.GetJoins())
+}
+
 func (q *Query) _forEachHasOneJoin(fn func(*join), joins []join) {
 	for i := range joins {
 		j := &joins[i]
@@ -831,14 +838,23 @@ func (q *Query) _forEachHasOneJoin(fn func(*join), joins []join) {
 	}
 }
 
+func (q *Query) _forEachHasManyJoin(fn func(*join), joins []join) {
+	for i := range joins {
+		j := &joins[i]
+		switch j.Rel.Type {
+		case HasManyRelation:
+			fn(j)
+			q._forEachHasManyJoin(fn, j.JoinModel.GetJoins())
+		}
+	}
+}
+
 func (q *Query) selectJoins(joins []join) error {
 	var err error
 	for i := range joins {
 		j := &joins[i]
 		if j.Rel.Type == HasOneRelation || j.Rel.Type == BelongsToRelation {
 			err = q.selectJoins(j.JoinModel.GetJoins())
-		} else {
-			err = j.Select(q.New())
 		}
 		if err != nil {
 			return err


### PR DESCRIPTION
Currently if a model has a `has many` relationship and it is queried, then two SELECTs will be sent to PostgreSQL. 

Documented here: https://godoc.org/github.com/go-pg/pg#example-DB-Model-HasMany
Select user and all his active profiles with following queries:

### Current behavior:
```sql
SELECT "user".* FROM "users" AS "user" ORDER BY "user"."id" LIMIT 1;

SELECT "profile".* FROM "profiles" AS "profile"
WHERE (active IS TRUE) AND (("profile"."user_id") IN ((1)))
```

### Updated behavior:
```sql
SELECT
  "user"."id",
  "user"."name",
  json_agg(json_build_object('Id', "profile"."id", 'Lang', "profile"."lang", 'Active', "profile"."active", 'UserId', "profile"."user_id")) AS "profiles"
FROM "users" AS "user"
LEFT JOIN "profiles" AS "profile" ON "users"."id" = "profile"."user_id"
WHERE "profiles"."active" IS TRUE
```

This reduces the number of round trips needed to query data and has the potential to make it significantly easier to filter based on relational data.

This probably needs some work though, let me know what your thoughts are.