### PR TITLE
db: fix cancel request race condition on context timeout/cancellation

### DIFF
--- a/base.go
+++ b/base.go
@@ -130,16 +130,21 @@ func (db *baseDB) withConn(c context.Context, fn func(cn *pool.Conn) error) erro
 		fnDone = make(chan struct{})
 		go func() {
 			select {
-			case <-fnDone:
+			case <-fnDone: // fn has finished, skip cancel
 			case <-c.Done():
 				_ = db.cancelRequest(cn.ProcessId, cn.SecretKey)
+				// Indicate end of conn use
+				fnDone <- struct{}{}
 			}
 		}()
 	}
 
 	defer func() {
 		if fnDone != nil {
-			close(fnDone)
+			select {
+			case <-fnDone: // Wait for cancel to finish request
+			case fnDone <- struct{}{}: // Indicate fn finish, skip cancel goroutine
+			}
 		}
 		db.freeConn(cn, err)
 	}()

--- a/race_test.go
+++ b/race_test.go
@@ -188,6 +188,19 @@ var _ = Describe("DB race", func() {
 		})
 	})
 
+	It("context timeout is race free", func() {
+		perform(C, func(id int) {
+			for i := 0; i < N; i++ {
+				func() {
+					ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+					defer cancel()
+					_, err := db.ExecContext(ctx, "SELECT 1")
+					Expect(err).NotTo(HaveOccurred())
+				}()
+			}
+		})
+	})
+
 	It("fully initializes model table", func() {
 		type TestTable struct {
 			tableName struct{} `sql:"'generate_series(0, 9)'"`


### PR DESCRIPTION
When passing a timeout context into the db queries, there currently
exists a race condition where a select between query finish and context
done can choose the context, and go on to send a cancel request on a
conn that has already been freed. So a concurrent request may pick up
the same conn but is cancelled by this orphaned request.

There is a similar fix in https://github.com/lib/pq/pull/578 where we
use the same channel to pass flow between fn finish and cancel
goroutines. close() is async so a select cannot guarantee executing one
case at a time.

Added a test in race_test to prove the problem and the fix.