### PR TITLE
Fix connection removal for single pool

### DIFF
--- a/internal/pool/pool_single.go
+++ b/internal/pool/pool_single.go
@@ -82,12 +82,10 @@ func (p *SingleConnPool) Put(cn *Conn) {
 }
 
 func (p *SingleConnPool) Remove(cn *Conn) {
-	defer func() {
-		if recover() != nil {
-			p.pool.Remove(cn)
-		}
-	}()
-	p.ch <- cn
+	// Remove connection from source pool and switch state to default
+	if atomic.CompareAndSwapUint32(&p.state, stateInited, stateDefault) {
+		p.pool.Remove(cn)
+	}
 }
 
 func (p *SingleConnPool) Len() int {


### PR DESCRIPTION
`Remove` on the `SingleConnPool` now removes the connection
also from the source pool and resets the state of the
`SingleConnPool` to `Inited`.

This fixes an error that when a connection fails, it was readded to the pool and the next time a SingleConnPool is initiated, it would use the failed connection, so it would never be removed from the pool.

The `Remove` function is only called from `base.go` when `initConn` fails or when `freeConn` is called with a connection error, so I think it's save to always remove the connection also from the source pool, because there is (currently) no case when `SingleConnPool.Remove` is called on a healthy connection.

Fixes the problem described in https://github.com/go-pg/pg/issues/1169#issue-430352506