### PR TITLE
Fix: Add missing brackets and add test for that case

### DIFF
--- a/orm/insert.go
+++ b/orm/insert.go
@@ -137,7 +137,7 @@ func (q *insertQuery) appendValues(b []byte, fields []*Field, strct reflect.Valu
 		switch {
 		case q.placeholder:
 			b = append(b, '?')
-		case f.Default != "" || f.OmitZero() && f.IsZeroValue(strct):
+		case (f.Default != "" || f.OmitZero()) && f.IsZeroValue(strct):
 			b = append(b, "DEFAULT"...)
 			q.addReturningField(f)
 		default:

--- a/orm/insert_test.go
+++ b/orm/insert_test.go
@@ -37,6 +37,11 @@ type InsertNullTest struct {
 	F4 int `sql:",pk,notnull"`
 }
 
+type InsertDefaultTest struct {
+	Id    int
+	Value string `sql:"default:hello"`
+}
+
 type InsertQTest struct {
 	Geo  types.Q
 	Func types.ValueAppender
@@ -138,6 +143,14 @@ var _ = Describe("Insert", func() {
 		b, err := (&insertQuery{q: q}).AppendQuery(nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(b)).To(Equal(`INSERT INTO name ("id", "field", "field2") VALUES (DEFAULT, DEFAULT, DEFAULT) RETURNING "id", "field", "field2"`))
+	})
+
+	It("supports value when default value is set", func() {
+		q := NewQuery(nil, &InsertDefaultTest{Id: 1, Value: "world"})
+
+		b, err := (&insertQuery{q: q}).AppendQuery(nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(b)).To(Equal(`INSERT INTO "insert_default_tests" ("id", "value") VALUES (1, 'world')`))
 	})
 
 	It("supports notnull", func() {


### PR DESCRIPTION
Fixes an error introduced in #1185 where brackets where missing in a switch-case in `orm/insert.go`.