### PR TITLE
Add support for connect_timeout option

### DIFF
--- a/options.go
+++ b/options.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/url"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -206,8 +207,18 @@ func ParseURL(sURL string) (*Options, error) {
 
 	delete(query, "application_name")
 
+	if connTimeout, ok := query["connect_timeout"]; ok && len(connTimeout) > 0 {
+		ct, err := strconv.Atoi(connTimeout[0])
+		if err != nil {
+			return nil, fmt.Errorf("pg: cannot parse connect_timeout option as int")
+		}
+		options.DialTimeout = time.Second * time.Duration(ct)
+	}
+
+	delete(query, "connect_timeout")
+
 	if len(query) > 0 {
-		return nil, errors.New("pg: options other than 'sslmode' and 'application_name' are not supported")
+		return nil, errors.New("pg: options other than 'sslmode', 'application_name' and 'connect_timeout' are not supported")
 	}
 
 	return options, nil

--- a/options_test.go
+++ b/options_test.go
@@ -5,18 +5,20 @@ package pg
 import (
 	"errors"
 	"testing"
+	"time"
 )
 
 func TestParseURL(t *testing.T) {
 	cases := []struct {
-		url      string
-		addr     string
-		user     string
-		password string
-		database string
-		appName  string
-		tls      bool
-		err      error
+		url         string
+		addr        string
+		user        string
+		password    string
+		database    string
+		appName     string
+		dialTimeout time.Duration
+		tls         bool
+		err         error
 	}{
 		{
 			"postgres://vasya:pupkin@somewhere.at.amazonaws.com:5432/postgres",
@@ -25,6 +27,7 @@ func TestParseURL(t *testing.T) {
 			"pupkin",
 			"postgres",
 			"",
+			0,
 			true,
 			nil,
 		},
@@ -35,6 +38,7 @@ func TestParseURL(t *testing.T) {
 			"pupkin",
 			"postgres",
 			"",
+			0,
 			true,
 			nil,
 		},
@@ -45,6 +49,7 @@ func TestParseURL(t *testing.T) {
 			"pupkin",
 			"postgres",
 			"",
+			0,
 			true,
 			nil,
 		},
@@ -55,6 +60,7 @@ func TestParseURL(t *testing.T) {
 			"pupkin",
 			"postgres",
 			"",
+			0,
 			true,
 			nil,
 		},
@@ -65,6 +71,7 @@ func TestParseURL(t *testing.T) {
 			"pupkin",
 			"postgres",
 			"",
+			0,
 			true,
 			errors.New("pg: sslmode 'verify-ca' is not supported"),
 		},
@@ -75,6 +82,7 @@ func TestParseURL(t *testing.T) {
 			"pupkin",
 			"postgres",
 			"",
+			0,
 			true,
 			errors.New("pg: sslmode 'verify-full' is not supported"),
 		},
@@ -85,6 +93,7 @@ func TestParseURL(t *testing.T) {
 			"pupkin",
 			"postgres",
 			"",
+			0,
 			false,
 			nil,
 		},
@@ -95,6 +104,7 @@ func TestParseURL(t *testing.T) {
 			"pupkin",
 			"postgres",
 			"myApp",
+			0,
 			false,
 			nil,
 		},
@@ -105,6 +115,7 @@ func TestParseURL(t *testing.T) {
 			"pupkin",
 			"postgres",
 			"myApp",
+			0,
 			false,
 			nil,
 		},
@@ -115,6 +126,7 @@ func TestParseURL(t *testing.T) {
 			"pupkin",
 			"",
 			"",
+			0,
 			true,
 			errors.New("pg: database name not provided"),
 		},
@@ -125,6 +137,7 @@ func TestParseURL(t *testing.T) {
 			"pupkin",
 			"postgres",
 			"",
+			0,
 			true,
 			nil,
 		},
@@ -135,8 +148,9 @@ func TestParseURL(t *testing.T) {
 			"pupkin",
 			"postgres",
 			"",
+			0,
 			true,
-			errors.New("pg: options other than 'sslmode' and 'application_name' are not supported"),
+			errors.New("pg: options other than 'sslmode', 'application_name' and 'connect_timeout' are not supported"),
 		},
 		{
 			"postgres://vasya@somewhere.at.amazonaws.com:5432/postgres",
@@ -145,6 +159,7 @@ func TestParseURL(t *testing.T) {
 			"",
 			"postgres",
 			"",
+			0,
 			true,
 			nil,
 		},
@@ -155,6 +170,7 @@ func TestParseURL(t *testing.T) {
 			"",
 			"postgres",
 			"",
+			0,
 			true,
 			nil,
 		},
@@ -165,6 +181,7 @@ func TestParseURL(t *testing.T) {
 			"",
 			"postgres",
 			"",
+			0,
 			true,
 			nil,
 		},
@@ -175,8 +192,31 @@ func TestParseURL(t *testing.T) {
 			"",
 			"test",
 			"",
+			0,
 			true,
 			errors.New("pg: invalid scheme: http"),
+		},
+		{
+			"postgresql://pg.example.com:5432/db?connect_timeout=10",
+			"pg.example.com:5432",
+			"postgres",
+			"",
+			"db",
+			"",
+			time.Second * 10,
+			true,
+			nil,
+		},
+		{
+			"postgresql://pg.example.com:5432/db?connect_timeout=10s",
+			"pg.example.com:5432",
+			"postgres",
+			"",
+			"db",
+			"",
+			0,
+			true,
+			errors.New("pg: cannot parse connect_timeout option as int"),
 		},
 	}
 


### PR DESCRIPTION
This commit adds support for connect_timeout option in the connection
string parsed by ParseURL function.

Support for this option provides more compatibility with libpq.
Ref: https://www.postgresql.org/docs/9.6/libpq-connect.html