### PR TITLE
Added support for creating model tables with partition options.

### DIFF
--- a/orm/table.go
+++ b/orm/table.go
@@ -54,6 +54,8 @@ type Table struct {
 
 	Tablespace types.Q
 
+	PartitionBy string
+
 	allFields     []*Field // read only
 	skippedFields []*Field
 
@@ -293,6 +295,12 @@ func (t *Table) newField(f reflect.StructField, index []int) *Field {
 		if ok {
 			s, _ := tagparser.Unquote(tableSpace)
 			t.Tablespace = quoteID(s)
+		}
+
+		partitionType, ok := sqlTag.Options["partitionBy"]
+		if ok {
+			s, _ := tagparser.Unquote(partitionType)
+			t.PartitionBy = s
 		}
 
 		if sqlTag.Name == "_" {

--- a/orm/table_create.go
+++ b/orm/table_create.go
@@ -116,6 +116,11 @@ func (q *createTableQuery) AppendQuery(fmter QueryFormatter, b []byte) (_ []byte
 
 	b = append(b, ")"...)
 
+	if table.PartitionBy != "" {
+		b = append(b, " PARTITION BY "...)
+		b = append(b, table.PartitionBy...)
+	}
+
 	if table.Tablespace != "" {
 		b = q.appendTablespace(b, table.Tablespace)
 	}

--- a/orm/table_create_test.go
+++ b/orm/table_create_test.go
@@ -61,6 +61,28 @@ type CreateTableWithTablespace struct {
 	String string
 }
 
+type CreateTableWithRangePartition struct {
+	tableName string `sql:"partitionBy:RANGE (time)"`
+
+	Time   time.Time
+	String string
+}
+
+type CreateTableWithListPartition struct {
+	tableName string `sql:"partitionBy:LIST (country)"`
+
+	Country string
+	String  string
+}
+
+type CreateTableWithHashPartition struct {
+	tableName string `sql:"partitionBy:HASH (account_id)"`
+
+	ID        int
+	AccountID int
+	String    string
+}
+
 var _ = Describe("CreateTable", func() {
 	It("creates new table", func() {
 		q := NewQuery(nil, &CreateTableModel{})
@@ -95,6 +117,27 @@ var _ = Describe("CreateTable", func() {
 
 		s := createTableQueryString(q, &CreateTableOptions{})
 		Expect(s).To(Equal(`CREATE TABLE "create_table_with_tablespaces" ("string" text) TABLESPACE "ssd"`))
+	})
+
+	It("creates new table with range partition", func() {
+		q := NewQuery(nil, &CreateTableWithRangePartition{})
+
+		s := createTableQueryString(q, &CreateTableOptions{})
+		Expect(s).To(Equal(`CREATE TABLE "create_table_with_range_partitions" ("time" timestamptz, "string" text) PARTITION BY RANGE (time)`))
+	})
+
+	It("creates new table with list partition", func() {
+		q := NewQuery(nil, &CreateTableWithListPartition{})
+
+		s := createTableQueryString(q, &CreateTableOptions{})
+		Expect(s).To(Equal(`CREATE TABLE "create_table_with_list_partitions" ("country" text, "string" text) PARTITION BY LIST (country)`))
+	})
+
+	It("creates new table with hash partition", func() {
+		q := NewQuery(nil, &CreateTableWithHashPartition{})
+
+		s := createTableQueryString(q, &CreateTableOptions{})
+		Expect(s).To(Equal(`CREATE TABLE "create_table_with_hash_partitions" ("id" bigserial, "account_id" bigint, "string" text, PRIMARY KEY ("id")) PARTITION BY HASH (account_id)`))
 	})
 })
 


### PR DESCRIPTION
This will allow a model's table to be created with options for partitions.
Allowing users to then create the individual partition tables manually
but still letting go-pg/pg manage the initial table creation.

The main reason for this is; we are using an account_id column for all of our tables. But we want to partition our tables using PostgreSQL's partition feature by account_id and hash. We also want to add some partitioning even further on some of those tables where we keep archived or deleted records in their own partition on a tablespace that resides on a slower hard drive. While keeping active records on a different partition on a faster tablespace.

This will make it so the initial creation of our tables is much easier, and we can manage creating the individual partitions manually by just inheriting the parent table.

More documentation here: https://www.postgresql.org/docs/12/ddl-partitioning.html