### PR TITLE
Replace busy loops with sync.Once in SingleConnPool

### DIFF
--- a/internal/pool/pool_single.go
+++ b/internal/pool/pool_single.go
@@ -51,11 +51,10 @@ func (p *SingleConnPool) Clone() *SingleConnPool {
 }
 
 func (p *SingleConnPool) SetConn(cn *Conn) {
-	if atomic.CompareAndSwapUint32(&p.state, stateDefault, stateInited) {
+	p.setup().once.Do(func() {
+		atomic.StoreUint32(&p.state, stateInited)
 		p.ch <- cn
-		return
-	}
-	panic("not reached")
+	})
 }
 
 func (p *SingleConnPool) NewConn(c context.Context) (*Conn, error) {

--- a/internal/pool/pool_single.go
+++ b/internal/pool/pool_single.go
@@ -163,7 +163,7 @@ func (p *SingleConnPool) Reset() error {
 
 	cn, ok := <-p.ch
 	if !ok {
-		return fmt.Errorf("pg: SingleConnPool does not have a Conn")
+		return fmt.Errorf("pg: SingleConnPool is closed")
 	}
 	p.pool.Remove(cn)
 


### PR DESCRIPTION
Inspecting the code I saw some busy loops to do synchronized setup. Using sync.Once seems like a better solution for this.