### PR TITLE
Added support for omitting zero values from batch updates.

### DIFF
--- a/orm/update.go
+++ b/orm/update.go
@@ -229,8 +229,16 @@ func (q *updateQuery) appendSetSlice(b []byte) ([]byte, error) {
 
 		b = append(b, f.Column...)
 		b = append(b, " = "...)
+		if q.omitZero {
+			b = append(b, "COALESCE("...)
+		}
 		b = append(b, "_data."...)
 		b = append(b, f.Column...)
+		if q.omitZero {
+			b = append(b, ", "...)
+			b = append(b, f.Column...)
+			b = append(b, ")"...)
+		}
 	}
 
 	return b, nil

--- a/orm/update_test.go
+++ b/orm/update_test.go
@@ -74,6 +74,19 @@ var _ = Describe("Update", func() {
 		Expect(s).To(Equal(`UPDATE "update_tests" AS "update_test" SET "value" = _data."value" FROM (VALUES (123, 'hello'::mytype), (123, NULL::mytype)) AS _data("id", "value") WHERE "update_test"."id" = _data."id"`))
 	})
 
+	It("bulk updates with zero values", func() {
+		slice := []*UpdateTest{{
+			Id:    1,
+			Value: "hello",
+		}, {
+			Id: 2,
+		}}
+		q := NewQuery(nil, &slice)
+
+		s := updateQueryStringWithBlanks(q)
+		Expect(s).To(Equal(`UPDATE "update_tests" AS "update_test" SET "value" = COALESCE(_data."value", "value") FROM (VALUES (1, 'hello'::mytype), (2, NULL::mytype)) AS _data("id", "value") WHERE "update_test"."id" = _data."id"`))
+	})
+
 	It("returns an error for empty bulk update", func() {
 		slice := make([]UpdateTest, 0)
 		q := NewQuery(nil, &slice)
@@ -121,6 +134,12 @@ var _ = Describe("Update", func() {
 
 func updateQueryString(q *Query) string {
 	upd := newUpdateQuery(q, false)
+	s := queryString(upd)
+	return s
+}
+
+func updateQueryStringWithBlanks(q *Query) string {
+	upd := newUpdateQuery(q, true)
 	s := queryString(upd)
 	return s
 }


### PR DESCRIPTION
In a batch update it already correctly asserts that a zero value field
should be represented as such. But because it sends all data in the
update during a batch update it can still overwrite the existing value.

This solves that problem by adding a COALESCE around the value set
portion of the update statement so that if the value provided from the
ORM is null then it will not overwrite the existing database value.

This only affects updates done with slices. Single record updates 
behave as they should currently.