### PR TITLE
Added handling of serial column types in updates.

### DIFF
--- a/orm/update.go
+++ b/orm/update.go
@@ -222,6 +222,11 @@ func (q *updateQuery) appendSetSlice(b []byte) ([]byte, error) {
 		fields = q.q.model.Table().DataFields
 	}
 
+	var table *Table
+	if q.omitZero {
+		table = q.q.model.Table()
+	}
+
 	for i, f := range fields {
 		if i > 0 {
 			b = append(b, ", "...)
@@ -229,13 +234,17 @@ func (q *updateQuery) appendSetSlice(b []byte) ([]byte, error) {
 
 		b = append(b, f.Column...)
 		b = append(b, " = "...)
-		if q.omitZero {
+		if q.omitZero && table != nil {
 			b = append(b, "COALESCE("...)
 		}
 		b = append(b, "_data."...)
 		b = append(b, f.Column...)
-		if q.omitZero {
+		if q.omitZero && table != nil {
 			b = append(b, ", "...)
+			if table.Alias != table.FullName {
+				b = append(b, table.Alias...)
+				b = append(b, '.')
+			}
 			b = append(b, f.Column...)
 			b = append(b, ")"...)
 		}
@@ -310,10 +319,8 @@ func (q *updateQuery) appendValues(
 		} else {
 			b = f.AppendValue(b, indirect(strct), 1)
 		}
-		if f.HasFlag(customTypeFlag) {
-			b = append(b, "::"...)
-			b = append(b, f.SQLType...)
-		}
+		b = append(b, "::"...)
+		b = append(b, f.SQLType...)
 	}
 	return b, nil
 }

--- a/orm/update_test.go
+++ b/orm/update_test.go
@@ -10,6 +10,11 @@ type UpdateTest struct {
 	Value string `sql:"type:mytype"`
 }
 
+type SerialUpdateTest struct {
+	Id    uint64 `sql:"type:bigint,pk"`
+	Value string
+}
+
 var _ = Describe("Update", func() {
 	It("updates model", func() {
 		q := NewQuery(nil, &UpdateTest{}).WherePK()
@@ -58,7 +63,7 @@ var _ = Describe("Update", func() {
 		})
 
 		s := updateQueryString(q)
-		Expect(s).To(Equal(`UPDATE "update_tests" AS "update_test" SET "value" = _data."value" FROM (VALUES (1, 'hello'::mytype), (2, NULL::mytype)) AS _data("id", "value") WHERE "update_test"."id" = _data."id"`))
+		Expect(s).To(Equal(`UPDATE "update_tests" AS "update_test" SET "value" = _data."value" FROM (VALUES (1::bigint, 'hello'::mytype), (2::bigint, NULL::mytype)) AS _data("id", "value") WHERE "update_test"."id" = _data."id"`))
 	})
 
 	It("bulk updates overriding column value", func() {
@@ -84,7 +89,18 @@ var _ = Describe("Update", func() {
 		q := NewQuery(nil, &slice)
 
 		s := updateQueryStringWithBlanks(q)
-		Expect(s).To(Equal(`UPDATE "update_tests" AS "update_test" SET "value" = COALESCE(_data."value", "value") FROM (VALUES (1, 'hello'::mytype), (2, NULL::mytype)) AS _data("id", "value") WHERE "update_test"."id" = _data."id"`))
+		Expect(s).To(Equal(`UPDATE "update_tests" AS "update_test" SET "value" = COALESCE(_data."value", "update_test"."value") FROM (VALUES (1::bigint, 'hello'::mytype), (2::bigint, NULL::mytype)) AS _data("id", "value") WHERE "update_test"."id" = _data."id"`))
+	})
+
+	It("bulk updates with serial id", func() {
+		slice := []*SerialUpdateTest{{
+			Id:    1,
+			Value: "hello",
+		}}
+		q := NewQuery(nil, &slice)
+
+		s := updateQueryString(q)
+		Expect(s).To(Equal(`UPDATE "serial_update_tests" AS "serial_update_test" SET "value" = _data."value" FROM (VALUES (1::bigint, 'hello'::text)) AS _data("id", "value") WHERE "serial_update_test"."id" = _data."id"`))
 	})
 
 	It("returns an error for empty bulk update", func() {


### PR DESCRIPTION
When performing a bulk update previously it would try to cast the fields
that were "bigserial" or "serial" to those types in the from clause. But
because they are not actual types in PostgreSQL and are just aliases, it
would cause an error when executing the query. This resolves that by
making sure that serial columns are cast to their base type instead.

This fixes the error:  `[42704] ERROR: type "bigserial" does not exist`