### PR TITLE
Backport #1329 and #1331 to v8 branch

### DIFF
--- a/orm/table.go
+++ b/orm/table.go
@@ -762,9 +762,6 @@ func fieldSQLType(field *Field, pgTag, sqlTag *tag.Tag) string {
 	}
 
 	sqlType := sqlType(field.Type)
-	if field.HasFlag(PrimaryKeyFlag) {
-		return pkSQLType(sqlType)
-	}
 
 	switch sqlType {
 	case "timestamptz":
@@ -824,23 +821,8 @@ func sqlType(typ reflect.Type) string {
 	}
 }
 
-func pkSQLType(s string) string {
-	switch s {
-	case "smallint":
-		return "smallserial"
-	case "integer":
-		return "serial"
-	case "bigint":
-		return "bigserial"
-	}
-	return s
-}
-
 func sqlTypeEqual(a, b string) bool {
-	if a == b {
-		return true
-	}
-	return pkSQLType(a) == pkSQLType(b)
+	return a == b
 }
 
 func (t *Table) tryHasOne(joinTable *Table, field *Field, pgTag *tag.Tag) bool {

--- a/orm/table_create.go
+++ b/orm/table_create.go
@@ -1,9 +1,8 @@
 package orm
 
 import (
-	"strconv"
-
 	"github.com/go-pg/pg/types"
+	"strconv"
 )
 
 type CreateTableOptions struct {

--- a/orm/table_create.go
+++ b/orm/table_create.go
@@ -1,8 +1,9 @@
 package orm
 
 import (
-	"github.com/go-pg/pg/types"
 	"strconv"
+
+	"github.com/go-pg/pg/types"
 )
 
 type CreateTableOptions struct {
@@ -70,14 +71,7 @@ func (q *createTableQuery) AppendQuery(b []byte) ([]byte, error) {
 
 		b = append(b, field.Column...)
 		b = append(b, " "...)
-		if q.opt != nil && q.opt.Varchar > 0 &&
-			field.SQLType == "text" && !field.HasFlag(customTypeFlag) {
-			b = append(b, "varchar("...)
-			b = strconv.AppendInt(b, int64(q.opt.Varchar), 10)
-			b = append(b, ")"...)
-		} else {
-			b = append(b, field.SQLType...)
-		}
+		b = q.appendSQLType(b, field)
 		if field.HasFlag(NotNullFlag) {
 			b = append(b, " NOT NULL"...)
 		}
@@ -108,6 +102,32 @@ func (q *createTableQuery) AppendQuery(b []byte) ([]byte, error) {
 	}
 
 	return b, q.q.stickyErr
+}
+
+func (q *createTableQuery) appendSQLType(b []byte, field *Field) []byte {
+	if q.opt != nil && q.opt.Varchar > 0 &&
+		field.SQLType == "text" && !field.HasFlag(customTypeFlag) {
+		b = append(b, "varchar("...)
+		b = strconv.AppendInt(b, int64(q.opt.Varchar), 10)
+		b = append(b, ")"...)
+		return b
+	}
+	if field.HasFlag(PrimaryKeyFlag) {
+		return append(b, pkSQLType(field.SQLType)...)
+	}
+	return append(b, field.SQLType...)
+}
+
+func pkSQLType(s string) string {
+	switch s {
+	case "smallint":
+		return "smallserial"
+	case "integer":
+		return "serial"
+	case "bigint":
+		return "bigserial"
+	}
+	return s
 }
 
 func appendPKConstraint(b []byte, pks []*Field) []byte {

--- a/orm/update.go
+++ b/orm/update.go
@@ -255,10 +255,8 @@ func (q *updateQuery) appendValues(b []byte, fields []*Field, strct reflect.Valu
 		} else {
 			b = f.AppendValue(b, indirect(strct), 1)
 		}
-		if f.HasFlag(customTypeFlag) {
-			b = append(b, "::"...)
-			b = append(b, f.SQLType...)
-		}
+		b = append(b, "::"...)
+		b = append(b, f.SQLType...)
 	}
 	return b
 }

--- a/orm/update_test.go
+++ b/orm/update_test.go
@@ -10,6 +10,11 @@ type UpdateTest struct {
 	Value string `sql:"type:mytype"`
 }
 
+type SerialUpdateTest struct {
+	Id    uint64 `sql:"type:bigint,pk"`
+	Value string
+}
+
 var _ = Describe("Update", func() {
 	It("updates model", func() {
 		q := NewQuery(nil, &UpdateTest{}).WherePK()
@@ -63,7 +68,7 @@ var _ = Describe("Update", func() {
 
 		b, err := (&updateQuery{q: q}).AppendQuery(nil)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(string(b)).To(Equal(`UPDATE "update_tests" AS "update_test" SET "value" = _data."value" FROM (VALUES (1, 'hello'::mytype), (2, NULL::mytype)) AS _data("id", "value") WHERE "update_test"."id" = _data."id"`))
+		Expect(string(b)).To(Equal(`UPDATE "update_tests" AS "update_test" SET "value" = _data."value" FROM (VALUES (1::bigint, 'hello'::mytype), (2::bigint, NULL::mytype)) AS _data("id", "value") WHERE "update_test"."id" = _data."id"`))
 	})
 
 	It("bulk updates overriding column value", func() {
@@ -78,6 +83,18 @@ var _ = Describe("Update", func() {
 		b, err := (&updateQuery{q: q}).AppendQuery(nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(b)).To(Equal(`UPDATE "update_tests" AS "update_test" SET "value" = _data."value" FROM (VALUES (123, 'hello'::mytype), (123, NULL::mytype)) AS _data("id", "value") WHERE "update_test"."id" = _data."id"`))
+	})
+
+	It("bulk updates with serial id", func() {
+		slice := []*SerialUpdateTest{{
+			Id:    1,
+			Value: "hello",
+		}}
+		q := NewQuery(nil, &slice)
+
+		b, err := (&updateQuery{q: q}).AppendQuery(nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(b)).To(Equal(`UPDATE "serial_update_tests" AS "serial_update_test" SET "value" = _data."value" FROM (VALUES (1::bigint, 'hello'::text)) AS _data("id", "value") WHERE "serial_update_test"."id" = _data."id"`))
 	})
 
 	It("returns an error for empty bulk update", func() {


### PR DESCRIPTION
This PR backports #1329 and #1331 to the v8 branch, to address #1351. #1351 is already fixed in master, but this will help people (including yours truly) who are stuck on v8 until v9 stabilizes.

Thanks for taking a look!