### PR TITLE
Allow for bulk deletes with custom where clause.

### DIFF
--- a/orm/delete.go
+++ b/orm/delete.go
@@ -82,19 +82,20 @@ func (q *deleteQuery) AppendQuery(fmter QueryFormatter, b []byte) (_ []byte, err
 	b = append(b, " WHERE "...)
 	value := q.q.model.Value()
 	if q.q.isSliceModelWithData() {
+		table := q.q.model.Table()
+		err = table.checkPKs()
+		if err != nil {
+			return nil, err
+		}
+
+		b = appendColumnAndSliceValue(fmter, b, value, table.Alias, table.PKs)
+
 		if len(q.q.where) > 0 {
+			b = append(b, " AND "...)
 			b, err = q.q.appendWhere(fmter, b)
 			if err != nil {
 				return nil, err
 			}
-		} else {
-			table := q.q.model.Table()
-			err = table.checkPKs()
-			if err != nil {
-				return nil, err
-			}
-
-			b = appendColumnAndSliceValue(fmter, b, value, table.Alias, table.PKs)
 		}
 	} else {
 		b, err = q.q.mustAppendWhere(fmter, b)

--- a/orm/delete_test.go
+++ b/orm/delete_test.go
@@ -18,6 +18,26 @@ var _ = Describe("Delete", func() {
 		s := deleteQueryString(q)
 		Expect(s).To(Equal(`WITH "wrapper" AS (SELECT  FROM "delete_tests" AS "delete_test") DELETE FROM "delete_tests" AS "delete_test" USING "wrapper" WHERE (delete_test.id = wrapper.id)`))
 	})
+
+	It("supports array with where", func() {
+		type DeleteWithPk struct {
+			Id        uint64 `sql:",pk"`
+			AccountId uint64
+			Name      string
+		}
+
+		q := NewQuery(nil, &[]DeleteWithPk{
+			{
+				Id: 1,
+			},
+			{
+				Id: 2,
+			},
+		}).Where("account_id = ?", 1)
+
+		s := deleteQueryString(q)
+		Expect(s).To(Equal(`DELETE FROM "delete_with_pks" AS "delete_with_pk" WHERE "delete_with_pk"."id" IN (1, 2) AND (account_id = 1)`))
+	})
 })
 
 func deleteQueryString(q *Query) string {


### PR DESCRIPTION
Previously if you were to add your own where clause onto a delete
statement. pg would ignore the original clause (where ID in...) and
would instead only use the clause you had provided. This change makes
it so pg will attempt to use both with an AND so that all conditions
must be met for a record to be deleted when deleting from an array of
models.

This will allow more security in a situation where you are restricting
what a single account could do, as well as other use cases.