### PR TITLE
Fixed issue where pointer uint64 values would panic during inserts.

### DIFF
--- a/orm/insert_test.go
+++ b/orm/insert_test.go
@@ -243,6 +243,27 @@ var _ = Describe("Insert", func() {
 		s := insertQueryString(q)
 		Expect(s).To(Equal(`INSERT INTO "dynamic_name" ("id") VALUES (DEFAULT) RETURNING "id"`))
 	})
+
+	It("support models with pointer uint", func() {
+		type UintModel struct {
+			Id      int
+			OtherId *uint64
+		}
+		v := uint64(2)
+		q := NewQuery(nil, &[]UintModel{
+			{
+				Id:      1,
+				OtherId: &v,
+			},
+			{
+				Id:      2,
+				OtherId: nil,
+			},
+		})
+
+		s := insertQueryString(q)
+		Expect(s).To(Equal(`INSERT INTO "uint_models" ("id", "other_id") VALUES (1, 2), (2, DEFAULT) RETURNING "other_id"`))
+	})
 })
 
 func insertQueryString(q *Query) string {

--- a/orm/table.go
+++ b/orm/table.go
@@ -973,7 +973,12 @@ func scanJSONValue(v reflect.Value, rd types.Reader, n int) error {
 }
 
 func appendUintAsInt(b []byte, v reflect.Value, _ int) []byte {
-	return strconv.AppendInt(b, int64(v.Uint()), 10)
+	switch v.Kind() {
+	case reflect.Ptr:
+		return strconv.AppendInt(b, int64(v.Elem().Uint()), 10)
+	default:
+		return strconv.AppendInt(b, int64(v.Uint()), 10)
+	}
 }
 
 func tryUnderscorePrefix(s string) string {


### PR DESCRIPTION
This was because we were trying to read the Uint value from the
reflection, but we had the pointer, not the actual reflected value. This
fixes the problem by checking to see if we were given a pointer and if
it is it will get the value from the address.