### PR TITLE
Loosen up error matching in test

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -299,7 +299,9 @@ var _ = Describe("DB", func() {
 		It("returns an error when query can't be prepared", func() {
 			for i := 0; i < 3; i++ {
 				_, err := db.Prepare("totally invalid sql")
-				Expect(err).To(MatchError(`ERROR #42601 syntax error at or near "totally"`))
+				Expect(err).NotTo(BeNil())
+				Expect(strings.Contains(err.Error(), "#42601")).To(BeTrue())
+				Expect(strings.Contains(err.Error(), "syntax error")).To(BeTrue())
 
 				_, err = db.Exec("SELECT 1")
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Previously, the test that checks that an error is returned when
PREPARE'ing a bogus SQL statement would check for the precise error
message. Now, the test will check that the correct error code is
returned as well as a reasonable error message (i.e. the matching
is less strict yet should be sufficient). The reason for the change
is that other databases that "speak" Postgres (for example CockroachDB)
might return an error that slightly deviates from PG but is still
reasonable.