### PR TITLE
Introduce environment variables to customize running tests

### DIFF
--- a/options.go
+++ b/options.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -99,10 +100,20 @@ func (opt *Options) init() {
 	if opt.Addr == "" {
 		switch opt.Network {
 		case "tcp":
-			opt.Addr = "localhost:5432"
+			host := env("PGHOST", "localhost")
+			port := env("PGPORT", "5432")
+			opt.Addr = fmt.Sprintf("%s:%s", host, port)
 		case "unix":
 			opt.Addr = "/var/run/postgresql/.s.PGSQL.5432"
 		}
+	}
+
+	if opt.User == "" {
+		opt.User = env("PGUSER", "postgres")
+	}
+
+	if opt.Database == "" {
+		opt.Database = env("PGDATABASE", "postgres")
 	}
 
 	if opt.PoolSize == 0 {
@@ -140,6 +151,14 @@ func (opt *Options) init() {
 	case 0:
 		opt.MaxRetryBackoff = 4 * time.Second
 	}
+}
+
+func env(key, defValue string) string {
+	envValue := os.Getenv(key)
+	if envValue != "" {
+		return envValue
+	}
+	return defValue
 }
 
 // ParseURL parses an URL into options that can be used to connect to PostgreSQL.


### PR DESCRIPTION
This commit adds the support of some environment variables (namely,
PGHOST, PGPORT, PGUSER, PGDATABASE, and PGSSLMODE) that override
certain options when running tests. The inspiration is taken from
lib/pq tests (https://www.postgresql.org/docs/9.3/libpq-envars.html).
For every option, the corresponding environment variable is first
checked. If it is present, then the value is used; if it is not present
or empty, then we fall back to using the default values.