### PR TITLE
Fix params in table name for many to many relation

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1009,7 +1009,7 @@ type Genre struct {
 	Name   string
 	Rating int `pg:"-"` // - is used to ignore field
 
-	Books []Book `pg:"many2many:book_genres"` // many to many relation
+	Books []Book `pg:"many2many:?shard.book_genres"` // many to many relation
 
 	ParentId  int
 	Subgenres []Genre `pg:"fk:parent_id"`
@@ -1133,7 +1133,7 @@ var _ = Describe("ORM", func() {
 	var db *pg.DB
 
 	BeforeEach(func() {
-		db = pg.Connect(pgOptions())
+		db = pg.Connect(pgOptions()).WithParam("shard", pg.Ident("public"))
 
 		err := createTestSchema(db)
 		Expect(err).NotTo(HaveOccurred())

--- a/orm/table.go
+++ b/orm/table.go
@@ -645,7 +645,7 @@ func (t *Table) tryRelationSlice(field *Field) bool {
 			Type:          Many2ManyRelation,
 			Field:         field,
 			JoinTable:     joinTable,
-			M2MTableName:  quoteIdent(m2mTableName),
+			M2MTableName:  types.Safe(m2mTableName),
 			M2MTableAlias: m2mTableAlias,
 			BaseFKs:       fks,
 			JoinFKs:       joinFKs,


### PR DESCRIPTION
The following syntax is used for multi-tenant or sharded applications:

	type Book struct {
		tableName struct{} `pg:"?shard.books"`
		Id        int
		Genres    []Genre `pg:"many2many:?shard.book_genres"`
	}

Commit f7218fc5e3fea9ea4ee9524fe206b3b4160c4cdb  introduced a regression that broke the `many2many` struct tag.

This is an attempt to fix the regression.