### PR TITLE
Do not use sql `DEFAULT` value when use_zero flag is on

### DIFF
--- a/orm/insert.go
+++ b/orm/insert.go
@@ -185,6 +185,8 @@ func (q *insertQuery) appendValues(
 		switch {
 		case q.placeholder:
 			b = append(b, '?')
+		case !f.NullZero() && f.HasZeroValue(strct):
+			b = f.AppendValue(b, strct, 1)
 		case (f.Default != "" || f.NullZero()) && f.HasZeroValue(strct):
 			b = append(b, "DEFAULT"...)
 			q.addReturningField(f)

--- a/orm/insert_test.go
+++ b/orm/insert_test.go
@@ -162,6 +162,16 @@ var _ = Describe("Insert", func() {
 		Expect(s).To(Equal(`INSERT INTO "insert_default_tests" ("id", "value") VALUES (1, DEFAULT) RETURNING "value"`))
 	})
 
+	It("supports value when default value and use_zero is used together", func() {
+		type EmptyValueModel struct {
+			Value string `pg:",use_zero,default:''"`
+		}
+		q := NewQuery(nil, &EmptyValueModel{})
+
+		s := insertQueryString(q)
+		Expect(s).To(Equal(`INSERT INTO "empty_value_models" ("value") VALUES ('')`))
+	})
+
 	It("supports RETURNING NULL", func() {
 		q := NewQuery(nil, &InsertDefaultTest{Id: 1}).Returning("NULL")
 


### PR DESCRIPTION
In my opinion, go-pg can use as an intermediate tool to the DB, but, it doesn't need to reflect the real DB structure and constraints.

So, if there was situation when model definition doesn't reflect DB column, use `DEFAULT` when `use_zero` and `default` tags use together can lead to `NULL` value in the database, even if I define `default` tag as empty value, go-pg should use my defined value as-is.

