### PR TITLE
bug fix when AfterSelect hook called in has many relation

### DIFF
--- a/orm/hook.go
+++ b/orm/hook.go
@@ -72,15 +72,17 @@ func callHookSlice2(
 	hook func(context.Context, reflect.Value) error,
 ) error {
 	var firstErr error
-	for i := 0; i < slice.Len(); i++ {
-		v := slice.Index(i)
-		if !ptr {
-			v = v.Addr()
-		}
+	if slice.IsValid() {
+		for i := 0; i < slice.Len(); i++ {
+			v := slice.Index(i)
+			if !ptr {
+				v = v.Addr()
+			}
 
-		err := hook(c, v)
-		if err != nil && firstErr == nil {
-			firstErr = err
+			err := hook(c, v)
+			if err != nil && firstErr == nil {
+				firstErr = err
+			}
 		}
 	}
 	return firstErr


### PR DESCRIPTION
When using AfterSelectHook and then the model has `has many` relation, error occured

```
reflect: call of reflect.Value.Len on zero Value
/usr/local/go/src/reflect/value.go:1086 (0x1087bed)
        Value.Len: panic(&ValueError{"reflect.Value.Len", v.kind()})
/Users/firmanalamsyah/Documents/go/src/github.com/go-pg/pg/orm/hook.go:75 (0x16cabea)
        callHookSlice2: for i := 0; i < slice.Len(); i++ {
/Users/firmanalamsyah/Documents/go/src/github.com/go-pg/pg/orm/hook.go:128 (0x16d7182)
        callAfterSelectHookSlice: return callHookSlice2(c, slice, ptr, callAfterSelectHook)
/Users/firmanalamsyah/Documents/go/src/github.com/go-pg/pg/orm/model_table_slice.go:113 (0x16d712f)
        (*sliceTableModel).AfterSelect: return callAfterSelectHookSlice(c, m.slice, m.sliceOfPtr)
/Users/firmanalamsyah/Documents/go/src/github.com/go-pg/pg/orm/query.go:835 (0x16e15fd)
        (*Query).Select: err = model.AfterSelect(c)
/Users/firmanalamsyah/Documents/go/src/github.com/go-pg/pg/orm/join.go:43 (0x16cdeeb)
        (*join).selectMany: return q.Select()
/Users/firmanalamsyah/Documents/go/src/github.com/go-pg/pg/orm/join.go:28 (0x16cde38)
        (*join).Select: return j.selectMany(fmter, q)
/Users/firmanalamsyah/Documents/go/src/github.com/go-pg/pg/orm/query.go:988 (0x16e2319)
        (*Query).selectJoins: err = j.Select(q.db.Formatter(), q.New())
/Users/firmanalamsyah/Documents/go/src/github.com/go-pg/pg/orm/query.go:829 (0x16e165c)
        (*Query).Select: if err := q.selectJoins(q.model.GetJoins()); err != nil {
/Users/firmanalamsyah/Documents/go/src/github.com/go-pg/pg/orm/join.go:43 (0x16cdeeb)
        (*join).selectMany: return q.Select()
/Users/firmanalamsyah/Documents/go/src/github.com/go-pg/pg/orm/join.go:28 (0x16cde38)
        (*join).Select: return j.selectMany(fmter, q)
/Users/firmanalamsyah/Documents/go/src/github.com/go-pg/pg/orm/query.go:988 (0x16e2319)
        (*Query).selectJoins: err = j.Select(q.db.Formatter(), q.New())
/Users/firmanalamsyah/Documents/go/src/github.com/go-pg/pg/orm/query.go:829 (0x16e165c)
        (*Query).Select: if err := q.selectJoins(q.model.GetJoins()); err != nil {
```

so i add condition check before `slice.Len()` called