### PR TITLE
Add possibility to override json library for jsonb fields

### DIFF
--- a/conv_test.go
+++ b/conv_test.go
@@ -10,9 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/segmentio/encoding/json"
-
 	"github.com/go-pg/pg/v9"
+	"github.com/go-pg/pg/v9/internal"
 	"github.com/go-pg/pg/v9/orm"
 	"github.com/go-pg/pg/v9/types"
 )
@@ -24,11 +23,11 @@ func (m *JSONMap) Scan(b interface{}) error {
 		*m = nil
 		return nil
 	}
-	return json.Unmarshal(b.([]byte), m)
+	return internal.Json.Unmarshal(b.([]byte), m)
 }
 
 func (m JSONMap) Value() (driver.Value, error) {
-	b, err := json.Marshal(m)
+	b, err := internal.Json.Marshal(m)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/json.go
+++ b/internal/json.go
@@ -1,0 +1,23 @@
+package internal
+
+import (
+	"io"
+)
+
+var Json JsonProvider
+
+type JsonProvider interface {
+	Marshal(v interface{}) ([]byte, error)
+	Unmarshal(data []byte, v interface{}) error
+	NewEncoder(writer io.Writer) JsonEncoder
+	NewDecoder(reader io.Reader) JsonDecoder
+}
+
+type JsonDecoder interface {
+	Decode(v interface{}) error
+	UseNumber()
+}
+
+type JsonEncoder interface {
+	Encode(v interface{}) error
+}

--- a/json.go
+++ b/json.go
@@ -1,0 +1,64 @@
+package pg
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/go-pg/pg/v9/internal"
+	json2 "github.com/segmentio/encoding/json"
+)
+
+type JsonProvider = internal.JsonProvider
+type JsonDecoder = internal.JsonDecoder
+type JsonEncoder = internal.JsonEncoder
+
+func init() {
+	SetJsonProvider(SegmentioJson{})
+}
+
+// Set JsonProvider used for jsonb fields encoding/decoding
+func SetJsonProvider(provider JsonProvider) {
+	internal.Json = provider
+}
+
+var _ JsonProvider = (*StdJson)(nil)
+
+type StdJson struct {
+}
+
+func (s StdJson) Marshal(v interface{}) ([]byte, error) {
+	return json.Marshal(v)
+}
+
+func (s StdJson) Unmarshal(data []byte, v interface{}) error {
+	return json.Unmarshal(data, v)
+}
+
+func (s StdJson) NewEncoder(w io.Writer) JsonEncoder {
+	return json.NewEncoder(w)
+}
+
+func (s StdJson) NewDecoder(r io.Reader) JsonDecoder {
+	return json.NewDecoder(r)
+}
+
+var _ JsonProvider = (*SegmentioJson)(nil)
+
+type SegmentioJson struct {
+}
+
+func (s SegmentioJson) Marshal(v interface{}) ([]byte, error) {
+	return json2.Marshal(v)
+}
+
+func (s SegmentioJson) Unmarshal(data []byte, v interface{}) error {
+	return json2.Unmarshal(data, v)
+}
+
+func (s SegmentioJson) NewEncoder(w io.Writer) JsonEncoder {
+	return json2.NewEncoder(w)
+}
+
+func (s SegmentioJson) NewDecoder(r io.Reader) JsonDecoder {
+	return json2.NewDecoder(r)
+}

--- a/orm/table.go
+++ b/orm/table.go
@@ -1005,7 +1005,7 @@ func scanJSONValue(v reflect.Value, rd types.Reader, n int) error {
 		return nil
 	}
 
-	dec := json.NewDecoder(rd)
+	dec := internal.Json.NewDecoder(rd)
 	dec.UseNumber()
 	return dec.Decode(v.Addr().Interface())
 }

--- a/types/append_jsonb_test.go
+++ b/types/append_jsonb_test.go
@@ -4,8 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/segmentio/encoding/json"
-
+	"github.com/go-pg/pg/v9/internal"
 	"github.com/go-pg/pg/v9/types"
 )
 
@@ -30,7 +29,7 @@ func TestAppendJSONB(t *testing.T) {
 }
 
 func BenchmarkAppendJSONB(b *testing.B) {
-	bytes, err := json.Marshal(jsonbTests)
+	bytes, err := internal.Json.Marshal(jsonbTests)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/types/append_value.go
+++ b/types/append_value.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/segmentio/encoding/json"
 	"github.com/vmihailenco/bufpool"
 
 	"github.com/go-pg/pg/v9/internal"
@@ -196,7 +195,7 @@ func appendJSONValue(b []byte, v reflect.Value, flags int) []byte {
 	buf := internal.GetBuffer()
 	defer internal.PutBuffer(buf)
 
-	if err := json.NewEncoder(buf).Encode(v.Interface()); err != nil {
+	if err := internal.Json.NewEncoder(buf).Encode(v.Interface()); err != nil {
 		return AppendError(b, err)
 	}
 

--- a/types/scan_value.go
+++ b/types/scan_value.go
@@ -283,7 +283,7 @@ func scanJSONValue(v reflect.Value, rd Reader, n int) error {
 		return nil
 	}
 
-	dec := json.NewDecoder(rd)
+	dec := internal.Json.NewDecoder(rd)
 	return dec.Decode(v.Addr().Interface())
 }
 


### PR DESCRIPTION
After 9.1.1 release we encountered a few problems with new json library, for example `segmentio/encoding` doesn't support `omitempty` tags.

This PR introduce new JsonProvider API allowing user to overwrite library used for jsonb fields keeping `segmentio/encoding` library as default.
