### PR TITLE
Use SetSoftDeleteField in sliceTableModel

### DIFF
--- a/orm/model_table_slice.go
+++ b/orm/model_table_slice.go
@@ -3,10 +3,8 @@ package orm
 import (
 	"context"
 	"reflect"
-	"time"
 
 	"github.com/go-pg/pg/v9/internal"
-	"github.com/go-pg/pg/v9/types"
 )
 
 type sliceTableModel struct {
@@ -158,21 +156,9 @@ func (m *sliceTableModel) AfterDelete(c context.Context) error {
 }
 
 func (m *sliceTableModel) setSoftDeleteField() {
-	field := m.table.SoftDeleteField
-	now := time.Now()
-	var value reflect.Value
-
-	switch {
-	case m.sliceOfPtr:
-		value = reflect.ValueOf(&now)
-	case field.Type == timeType:
-		value = reflect.ValueOf(now)
-	default:
-		value = reflect.ValueOf(types.NullTime{Time: now})
-	}
-
 	for i := 0; i < m.slice.Len(); i++ {
 		strct := indirect(m.slice.Index(i))
-		field.Value(strct).Set(value)
+		fv := m.table.SoftDeleteField.Value(strct)
+		m.table.SetSoftDeleteField(fv)
 	}
 }


### PR DESCRIPTION
This fixes two pointer related issues related to batch (slice) soft deleting.

1. Soft deleting a slice of pointer models with non-pointer soft delete fields.
2. Soft deleting a slice of non-pointer models with pointer soft delete fields.

Based on what I'm seeing in `structTableModel`, it would seem that using the recently introduced `Table.SetSoftDeleteField` function is the right way to go.