### PR TITLE
check if valuer is nil before appending to query

### DIFF
--- a/types/append.go
+++ b/types/append.go
@@ -191,6 +191,10 @@ func AppendBytes(b []byte, bytes []byte, flags int) []byte {
 }
 
 func appendDriverValuer(b []byte, v driver.Valuer, flags int) []byte {
+	ref := reflect.ValueOf(v)
+	if v == nil || (ref.Kind() == reflect.Ptr && ref.IsNil()) {
+		return AppendNull(b, flags)
+	}
 	value, err := v.Value()
 	if err != nil {
 		return AppendError(b, err)

--- a/types/append_test.go
+++ b/types/append_test.go
@@ -1,0 +1,46 @@
+package types
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"testing"
+)
+
+type valuer struct {
+	v string
+}
+func (v valuer) Value() (driver.Value, error) {
+	return v.v, nil
+}
+
+func TestAppend_ShouldAppendValue_WhenStruct(t *testing.T) {
+	input := "HelloWorld"
+	v := valuer{v: input}
+	output := Append([]byte{}, v, 1)
+
+	expectedOutput := fmt.Sprintf("'%s'", input)
+	if string(output) != expectedOutput {
+		t.Fatalf("Append expect: %s but got: %s", expectedOutput, string(output))
+	}
+}
+
+func TestAppend_ShouldAppendValue_WhenPtr(t *testing.T) {
+	input := "HelloWorld"
+	v := &valuer{v: input}
+	output := Append([]byte{}, v, 1)
+
+	expectedOutput := fmt.Sprintf("'%s'", input)
+	if string(output) != expectedOutput {
+		t.Fatalf("Append expect: %s but got: %s", expectedOutput, string(output))
+	}
+}
+
+func TestAppend_ShouldAppendNull_WhenPtrIsNil(t *testing.T) {
+	var v  *valuer = nil
+	output := Append([]byte{}, v, 1)
+
+	expectedOutput := "NULL"
+	if string(output) != expectedOutput {
+		t.Fatalf("Append expect: %s but got: %s", expectedOutput, string(output))
+	}
+}


### PR DESCRIPTION
Ran into some unexpected panics when passing a nil pointer of type `*decimal.Decimal` to `func (db *baseDB) Exec(query interface{}, params ...interface{}) (res Result, err error) {`

Are there any instructions on contributing to this repo?  Sorry if I missed them