### PR TITLE
Add PrintTableSchema function

### DIFF
--- a/orm/table_create.go
+++ b/orm/table_create.go
@@ -23,6 +23,17 @@ func CreateTable(db DB, model interface{}, opt *CreateTableOptions) error {
 	return NewQuery(db, model).CreateTable(opt)
 }
 
+func PrintTableSchema(model interface{}, opt *CreateTableOptions) (string, error) {
+	q := NewQuery(nil, model)
+	qq := newCreateTableQuery(q, opt)
+	fmter := NewFormatter().WithModel(qq)
+	b, err := qq.AppendQuery(fmter, nil)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
 type createTableQuery struct {
 	q   *Query
 	opt *CreateTableOptions


### PR DESCRIPTION
Instead of letting `go-pg` to create the table for me, I want to generate the schema creation sql and hand it to the database admin.

Since `newCreateTableQuery` is private, I added a new function called `PrintTableSchema` using code from https://github.com/go-pg/pg/blob/fdea7c12e9c5cb625a4b1abde625a4abdcc60e5c/orm/table_create_test.go#L172 