### PR TITLE
RegisterAppender and RegisterScanner only panic if the type was already explicitly registered

### DIFF
--- a/types/append_value.go
+++ b/types/append_value.go
@@ -55,6 +55,7 @@ func init() {
 }
 
 var appendersMap sync.Map
+var registeredAppendersMap sync.Map
 
 // RegisterAppender registers an appender func for the value type.
 // Expecting to be used only during initialization, it panics
@@ -64,12 +65,14 @@ func RegisterAppender(value interface{}, fn AppenderFunc) {
 }
 
 func registerAppender(typ reflect.Type, fn AppenderFunc) {
-	_, loaded := appendersMap.LoadOrStore(typ, fn)
+	_, loaded := registeredAppendersMap.LoadOrStore(typ, fn)
 	if loaded {
 		err := fmt.Errorf("pg: appender for the type=%s is already registered",
 			typ.String())
 		panic(err)
 	}
+
+	appendersMap.Store(typ, fn)
 }
 
 func Appender(typ reflect.Type) AppenderFunc {

--- a/types/append_value_test.go
+++ b/types/append_value_test.go
@@ -1,0 +1,66 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRegisterAppender(t *testing.T) {
+	tests := []struct {
+		expression  func()
+		shouldPanic bool
+	}{
+		{
+			func() {
+				RegisterAppender(struct{}{}, nil)
+			},
+			false,
+		},
+		{
+			func() {
+				RegisterAppender(struct{ One string }{}, nil)
+				RegisterAppender(struct{ Two string }{}, nil)
+			},
+			false,
+		},
+		{
+			func() {
+				// Appender will implicitly assign a default appender
+				Appender(reflect.TypeOf(struct{ Three string }{}))
+				// This will override it but will not panic since it is the first
+				// explicit call to RegisterAppender for that type
+				RegisterAppender(struct{ Three string }{}, nil)
+			},
+			false,
+		},
+		{
+			func() {
+				RegisterAppender(struct{ Four string }{}, nil)
+				// This panics because we have already explicitly registered an appender
+				// for this type
+				RegisterAppender(struct{ Four string }{}, nil)
+			},
+			true,
+		},
+	}
+
+	for testi, test := range tests {
+		if causedPanic(test.expression) != test.shouldPanic {
+			t.Fatalf(
+				"test #%d expected shouldPanic to be %t, was %t",
+				testi, test.shouldPanic, !test.shouldPanic)
+		}
+	}
+}
+
+func causedPanic(f func()) bool {
+	didPanic := false
+
+	func() {
+		defer func() { didPanic = recover() != nil }()
+
+		f()
+	}()
+
+	return didPanic
+}

--- a/types/scan_value.go
+++ b/types/scan_value.go
@@ -59,6 +59,7 @@ func init() {
 }
 
 var scannersMap sync.Map
+var registeredScannersMap sync.Map
 
 // RegisterScanner registers an scanner func for the type.
 // Expecting to be used only during initialization, it panics
@@ -68,12 +69,14 @@ func RegisterScanner(value interface{}, fn ScannerFunc) {
 }
 
 func registerScanner(typ reflect.Type, fn ScannerFunc) {
-	_, loaded := scannersMap.LoadOrStore(typ, fn)
+	_, loaded := registeredScannersMap.LoadOrStore(typ, fn)
 	if loaded {
 		err := fmt.Errorf("pg: scanner for the type=%s is already registered",
 			typ.String())
 		panic(err)
 	}
+
+	scannersMap.Store(typ, fn)
 }
 
 func Scanner(typ reflect.Type) ScannerFunc {

--- a/types/scan_value_test.go
+++ b/types/scan_value_test.go
@@ -1,0 +1,54 @@
+package types
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRegisterScanner(t *testing.T) {
+	tests := []struct {
+		expression  func()
+		shouldPanic bool
+	}{
+		{
+			func() {
+				RegisterScanner(struct{}{}, nil)
+			},
+			false,
+		},
+		{
+			func() {
+				RegisterScanner(struct{ One string }{}, nil)
+				RegisterScanner(struct{ Two string }{}, nil)
+			},
+			false,
+		},
+		{
+			func() {
+				// Scanner will implicitly assign a default scanner
+				Scanner(reflect.TypeOf(struct{ Three string }{}))
+				// This will override it but will not panic since it is the first
+				// explicit call to RegisterScanner for that type
+				RegisterScanner(struct{ Three string }{}, nil)
+			},
+			false,
+		},
+		{
+			func() {
+				RegisterScanner(struct{ Four string }{}, nil)
+				// This panics because we have already explicitly registered a scanner
+				// for this type
+				RegisterScanner(struct{ Four string }{}, nil)
+			},
+			true,
+		},
+	}
+
+	for testi, test := range tests {
+		if causedPanic(test.expression) != test.shouldPanic {
+			t.Fatalf(
+				"test #%d expected shouldPanic to be %t, was %t",
+				testi, test.shouldPanic, !test.shouldPanic)
+		}
+	}
+}


### PR DESCRIPTION
When registering a scanner or an appender, only panic if the type has 
already been explicitly registered with `types.RegisterScanner` or
`types.RegisterAppender`, rather than if it was implicitly set to a default as a
side-effect of `types.Appender` or `types.Scanner` being called.

This avoids a race where a previous call to `types.Appender` or
`types.Scanner` which were invoked as a side-effect assigned a default
`Appender/Scanner` which then causes a subsequent call to
`Register{Appender,Scanner}` to panic. This can happen if, for example,
`orm.GetTable` is invoked before an `init()` function that calls Register
gets invoked due to unlucky package import ordering, since `orm.GetTable`
tries to look up the type's `Appender/Scanner`.

Example:
```go
  // This package gets imported first
  package bar

  type MyStruct struct {
    MyType MyType
  }

  var Table = orm.TableFor(&MyStruct{})
```
```go
  // This package gets imported second
  package foo

  type MyType struct {}

  func init() {
    // This panics because orm.TableFor called types.Appender and,
    finding none, set a default
    types.RegisterAppender(&MyType{}, ...)
  }
```