### PR TITLE
Reproduce an error with Bool fields and UpdateNonZero

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,17 @@ all:
 	go test ./... -run=NONE -bench=. -benchmem
 	env GOOS=linux GOARCH=386 go test ./...
 	golangci-lint run
+
+.PHONY: cleanTest
+cleanTest:
+	docker rm -fv pg || true
+
+.PHONY: pre-test
+pre-test: cleanTest
+	docker run -d --name pg -p 5432:5432 -e POSTGRES_HOST_AUTH_METHOD=trust postgres:9.6
+	sleep 10
+	docker exec pg psql -U postgres -c "CREATE EXTENSION hstore"
+
+.PHONY: test
+test: pre-test
+	PGSSLMODE=disable go test ./... -v

--- a/example_model_test.go
+++ b/example_model_test.go
@@ -796,6 +796,51 @@ func ExampleDB_Update_notZero() {
 	// Output: Book<Id=1 Title="updated book 1">
 }
 
+func ExampleDB_Update_notZero_Bool() {
+	type Event struct {
+		Id     int
+		Active bool `pg:",use_zero"`
+	}
+
+	db := pg.Connect(pgOptions())
+	defer db.Close()
+
+	err := db.Model((*Event)(nil)).CreateTable(&orm.CreateTableOptions{
+		Temp: true,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	event := &Event{
+		Id:     1,
+		Active: true,
+	}
+	_, err = db.Model(event).Insert()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(event)
+	// Output: Book<Id=1 Active="true">
+
+	event.Active = false
+
+	_, err = db.Model(event).WherePK().UpdateNotZero()
+	if err != nil {
+		panic(err)
+	}
+
+	event2 := new(Event)
+	err = db.Model(event2).Where("id = ?", 1).Select()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(event2)
+	// Output: Book<Id=1 Active="false">
+}
+
 func ExampleDB_Update_someColumns() {
 	db := modelDB()
 


### PR DESCRIPTION
## What does this PR do?
It adds a test creating an entity with a boolean attribute, marked as `use_zero` (as suggested in other issues).

This test creates the entity with the field set to TRUE, and right after the insert happens, the field is set to FALSE, the entity is updated with a call to UpdateNotZero.

To simplify running the tests locally, I added some automation in the makefile to spin up a Docker container for Postgres. Please run `make test` and it will:

- Remove previous existing container, if it exists
- Run the postgres container, listening on port 5432, binded to localhost
- Wait for the database with a sleep (could be improved with another approach - I did this fast)
- Create the hstore extension
- Run the tests, disabling PGSSLMODE

## Expected results
The field is updated with the new value (FALSE)

## Current results
Panic is raised when calling the update method, as the generated SQL is not correct: the bool field is not added.

```log
--- FAIL: ExampleDB_Update_notZero_Bool (0.01s)
panic: ERROR #42601 syntax error at or near "WHERE" [recovered]
	panic: ERROR #42601 syntax error at or near "WHERE"

goroutine 1 [running]:
testing.(*InternalExample).processRunResult(0xc0000f5d08, 0xc0004614b0, 0xa, 0xba4985, 0x162a940, 0xc001834750, 0x1015e50)
	/usr/local/Cellar/go/1.13.4/libexec/src/testing/example.go:89 +0x63f
testing.runExample.func2(0xbfc5af17f2bdf998, 0x80c38790f, 0x1c2a3a0, 0xc000204560, 0xc0000bc008, 0xc0004b7c20, 0xc0000f5d08, 0xc0000f5d38)
	/usr/local/Cellar/go/1.13.4/libexec/src/testing/run_example.go:58 +0x105
panic(0x162a940, 0xc001834750)
	/usr/local/Cellar/go/1.13.4/libexec/src/runtime/panic.go:679 +0x1b2
github.com/go-pg/pg/v10_test.ExampleDB_Update_notZero_Bool()
	/tmp/pg/example_model_test.go:831 +0x5ab
testing.runExample(0x16a6123, 0x1d, 0x16c1280, 0x16a4043, 0x1a, 0x0, 0x0)
	/usr/local/Cellar/go/1.13.4/libexec/src/testing/run_example.go:62 +0x209
testing.runExamples(0xc0000f5ed0, 0x1c249a0, 0x48, 0x48, 0x1)
	/usr/local/Cellar/go/1.13.4/libexec/src/testing/example.go:44 +0x1a8
testing.(*M).Run(0xc000464100, 0x0)
	/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:1118 +0x203
main.main()
	_testmain.go:242 +0x135
FAIL	github.com/go-pg/pg/v10	34.712s
```


**Postgres logs:**
```log
ERROR:  syntax error at or near "WHERE" at character 33
STATEMENT:  UPDATE "events" AS "event" SET  WHERE "event"."id" = 1
```

## Related issues
- Relates #1676
- Relates #973 
- Relates #518
- Relates #449 

## Other concerns
Maybe I've wrong assumptions in the usage of the library, so please consider closing this PR if you think my concerns are not valid.