### PR TITLE
Feat: Remove byte slice in ColumnAlloc

### DIFF
--- a/internal/pool/bench_test.go
+++ b/internal/pool/bench_test.go
@@ -77,3 +77,28 @@ func BenchmarkPoolGetRemove100Conns(b *testing.B) {
 func BenchmarkPoolGetRemove1000Conns(b *testing.B) {
 	benchmarkPoolGetRemove(b, 1000)
 }
+
+var columns = [][]byte{
+	[]byte("id"),
+	[]byte("business_phone"),
+	[]byte("display_name"),
+	[]byte("given_name"),
+	[]byte("job_title"),
+	[]byte("mail"),
+	[]byte("mobile_phone"),
+	[]byte("office_location"),
+	[]byte("preferred_language"),
+	[]byte("surname"),
+	[]byte("user_principal_name"),
+}
+
+func BenchmarkColumnAlloc(b *testing.B) {
+	columnAlloc := pool.NewColumnAlloc()
+	for i := 0; i < b.N; i++ {
+		for i, column := range columns {
+			columnAlloc.New(int16(i), column)
+		}
+		columnAlloc.Columns()
+		columnAlloc.Reset()
+	}
+}

--- a/internal/pool/reader.go
+++ b/internal/pool/reader.go
@@ -2,8 +2,6 @@ package pool
 
 import (
 	"sync"
-
-	"github.com/go-pg/pg/v10/internal"
 )
 
 type Reader interface {
@@ -39,16 +37,12 @@ func NewColumnAlloc() *ColumnAlloc {
 
 func (c *ColumnAlloc) Reset() {
 	c.columns = c.columns[:0]
-	c.name = nil
 }
 
 func (c *ColumnAlloc) New(index int16, name []byte) *ColumnInfo {
-	s := len(c.name)
-	c.name = append(c.name, name...)
-
 	c.columns = append(c.columns, ColumnInfo{
 		Index: index,
-		Name:  internal.BytesToString(c.name[s:]),
+		Name:  string(name),
 	})
 	return &c.columns[len(c.columns)-1]
 }


### PR DESCRIPTION
If we don't reuse ColumnaAlloc's byte slice, we can remove it and simple logic.

Benchmark with current version
```
➜  pool git:(v10) ✗ go test ./... -bench=BenchmarkColumnAlloc
Running Suite: pool
===================
Random Seed: 1604545377
Will run 23 of 23 specs

•••••••••••••••••••••••
Ran 23 of 23 Specs in 0.419 seconds
SUCCESS! -- 23 Passed | 0 Failed | 0 Pending | 0 Skipped
goos: darwin
goarch: amd64
pkg: github.com/go-pg/pg/v10/internal/pool
BenchmarkColumnAlloc-8           5052452               234 ns/op
PASS
ok      github.com/go-pg/pg/v10/internal/pool   2.151s
```

Benchmark with new version
```
➜  pool git:(feat-simple-column-alloc) go test ./... -bench=BenchmarkColumnAlloc
Running Suite: pool
===================
Random Seed: 1604545352
Will run 23 of 23 specs

•••••••••••••••••••••••
Ran 23 of 23 Specs in 0.379 seconds
SUCCESS! -- 23 Passed | 0 Failed | 0 Pending | 0 Skipped
goos: darwin
goarch: amd64
pkg: github.com/go-pg/pg/v10/internal/pool
BenchmarkColumnAlloc-8           4844086               237 ns/op
PASS
ok      github.com/go-pg/pg/v10/internal/pool   2.135s
```