### PR TITLE
added tstzrange support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/onsi/ginkgo v1.14.2
 	github.com/onsi/gomega v1.10.3
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1
 	github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc
 	github.com/vmihailenco/bufpool v0.1.11

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3 h1:gph6h/qe9GSUw1NhH1gp+qb+h8rXD8Cy60Z32Qw3ELA=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=

--- a/types/null_time_range.go
+++ b/types/null_time_range.go
@@ -1,0 +1,150 @@
+package types
+
+import (
+	"database/sql/driver"
+
+	"github.com/pkg/errors"
+)
+
+type BoundType byte
+
+const (
+	// named awkwardly to avoid collisions without checking
+	RBoundInclusive = BoundType('i')
+	RBoundExclusive = BoundType('e')
+	RBoundUnbounded = BoundType('U')
+	RBoundEmpty     = BoundType('E')
+)
+
+func (bt BoundType) String() string {
+	return string(bt)
+}
+
+// -----------------------------------------------------------------------------------------------------
+
+type NullTimeRange struct {
+	Lower     NullTime `json:"lower"`
+	Upper     NullTime `json:"upper"`
+	LowerType BoundType
+	UpperType BoundType
+}
+
+func (r *NullTimeRange) Scan(src interface{}) (err error) {
+	if src == nil {
+		r.decodeText(nil)
+		return
+	}
+
+	switch src := src.(type) {
+	case string:
+		return r.decodeText([]byte(src))
+	case []byte:
+		srcCopy := make([]byte, len(src))
+		copy(srcCopy, src)
+		return r.decodeText(srcCopy)
+	}
+
+	err = errors.Errorf("cannot scan %T", src)
+	return
+}
+
+func (r NullTimeRange) Value() (value driver.Value, err error) {
+	buf, err := r.encodeText(make([]byte, 0)) //, 32))
+	if err != nil {
+		return
+	}
+	if buf == nil {
+		return
+	}
+	value = string(buf)
+	return
+}
+
+func (r *NullTimeRange) decodeText(src []byte) error {
+	*r = NullTimeRange{
+		Lower:     NullTime{},
+		Upper:     NullTime{},
+		LowerType: RBoundEmpty,
+		UpperType: RBoundEmpty,
+	}
+	if src == nil {
+		return nil
+	}
+
+	utr, err := parseUntypedTextRange(string(src))
+	if err != nil {
+		return err
+	}
+
+	r.LowerType = utr.LowerType
+	r.UpperType = utr.UpperType
+
+	if r.LowerType == RBoundEmpty {
+		return nil
+	}
+
+	if r.LowerType == RBoundInclusive || r.LowerType == RBoundExclusive {
+		t, tsv, err := ParseTimeString(utr.Lower)
+		if err != nil {
+			return err
+		}
+		r.Lower.Time = t
+		r.Lower.Special = tsv
+	}
+
+	if r.UpperType == RBoundInclusive || r.UpperType == RBoundExclusive {
+		t, tsv, err := ParseTimeString(utr.Upper)
+		if err != nil {
+			return err
+		}
+		r.Upper.Time = t
+		r.Upper.Special = tsv
+	}
+
+	return nil
+}
+
+func (r NullTimeRange) encodeText(buf []byte) ([]byte, error) {
+
+	if (r.Lower.IsZero() && r.Lower.Special == TSVNone) || (r.Upper.IsZero() && r.Upper.Special == TSVNone) {
+		return nil, nil
+	}
+
+	switch r.LowerType {
+	case RBoundExclusive, RBoundUnbounded:
+		buf = append(buf, '(')
+	case RBoundInclusive:
+		buf = append(buf, '[')
+	case RBoundEmpty:
+		return append(buf, "empty"...), nil
+	default:
+		return nil, errors.Errorf("unknown lower bound type %v", r.LowerType)
+	}
+
+	if r.LowerType != RBoundUnbounded {
+		buf = r.Lower.forRange(buf)
+		if buf == nil {
+			return nil, errors.Errorf("lower cannot be null unless lowerType is unbounded")
+		}
+	}
+
+	buf = append(buf, ',')
+
+	if r.UpperType != RBoundUnbounded {
+		buf = r.Upper.forRange(buf)
+		if buf == nil {
+			return nil, errors.Errorf("upper cannot be null unless upperType is unbounded")
+		}
+	}
+
+	switch r.UpperType {
+	case RBoundExclusive, RBoundUnbounded:
+		buf = append(buf, ')')
+	case RBoundInclusive:
+		buf = append(buf, ']')
+	default:
+		return nil, errors.Errorf("unknown upper bound type %v", r.UpperType)
+	}
+
+	return buf, nil
+}

--- a/types/range.go
+++ b/types/range.go
@@ -1,0 +1,181 @@
+package types
+
+import (
+	"bytes"
+	"io"
+	"unicode"
+
+	"github.com/pkg/errors"
+)
+
+// -----------------------------------------------------------------------------------------------------
+// The code in this file is taken from github.com/jackc/pgtype and was slightly modified.
+// Modifications were aimed at only taking the code neccessary to fulfill the tstzrange requirements.
+// -----------------------------------------------------------------------------------------------------
+
+type UntypedTextRange struct {
+	Lower     string
+	Upper     string
+	LowerType BoundType
+	UpperType BoundType
+}
+
+func parseUntypedTextRange(src string) (*UntypedTextRange, error) {
+	utr := &UntypedTextRange{}
+	if src == "empty" {
+		utr.LowerType = RBoundEmpty
+		utr.UpperType = RBoundEmpty
+		return utr, nil
+	}
+
+	buf := bytes.NewBufferString(src)
+
+	skipWhitespace(buf)
+
+	r, _, err := buf.ReadRune()
+	if err != nil {
+		return nil, errors.Errorf("invalid Lower bound: %v", err)
+	}
+	switch r {
+	case '(':
+		utr.LowerType = RBoundExclusive
+	case '[':
+		utr.LowerType = RBoundInclusive
+	default:
+		return nil, errors.Errorf("missing Lower bound, instead got: %v", string(r))
+	}
+
+	r, _, err = buf.ReadRune()
+	if err != nil {
+		return nil, errors.Errorf("invalid Lower value: %v", err)
+	}
+	buf.UnreadRune()
+
+	if r == ',' {
+		utr.LowerType = RBoundUnbounded
+	} else {
+		utr.Lower, err = rangeParseValue(buf)
+		if err != nil {
+			return nil, errors.Errorf("invalid Lower value: %v", err)
+		}
+	}
+
+	r, _, err = buf.ReadRune()
+	if err != nil {
+		return nil, errors.Errorf("missing range separator: %v", err)
+	}
+	if r != ',' {
+		return nil, errors.Errorf("missing range separator: %v", r)
+	}
+
+	r, _, err = buf.ReadRune()
+	if err != nil {
+		return nil, errors.Errorf("invalid Upper value: %v", err)
+	}
+
+	if r == ')' || r == ']' {
+		utr.UpperType = RBoundUnbounded
+	} else {
+		buf.UnreadRune()
+		utr.Upper, err = rangeParseValue(buf)
+		if err != nil {
+			return nil, errors.Errorf("invalid Upper value: %v", err)
+		}
+
+		r, _, err = buf.ReadRune()
+		if err != nil {
+			return nil, errors.Errorf("missing Upper bound: %v", err)
+		}
+		switch r {
+		case ')':
+			utr.UpperType = RBoundExclusive
+		case ']':
+			utr.UpperType = RBoundInclusive
+		default:
+			return nil, errors.Errorf("missing Upper bound, instead got: %v", string(r))
+		}
+	}
+
+	skipWhitespace(buf)
+
+	if buf.Len() > 0 {
+		return nil, errors.Errorf("unexpected trailing data: %v", buf.String())
+	}
+
+	return utr, nil
+}
+
+// -----------------------------------------------------------------------------------------------------
+
+func rangeParseValue(buf *bytes.Buffer) (string, error) {
+	r, _, err := buf.ReadRune()
+	if err != nil {
+		return "", err
+	}
+	if r == '"' {
+		return rangeParseQuotedValue(buf)
+	}
+	buf.UnreadRune()
+
+	s := &bytes.Buffer{}
+
+	for {
+		r, _, err := buf.ReadRune()
+		if err != nil {
+			return "", err
+		}
+
+		switch r {
+		case '\\':
+			r, _, err = buf.ReadRune()
+			if err != nil {
+				return "", err
+			}
+		case ',', '[', ']', '(', ')':
+			buf.UnreadRune()
+			return s.String(), nil
+		}
+
+		s.WriteRune(r)
+	}
+}
+
+func rangeParseQuotedValue(buf *bytes.Buffer) (string, error) {
+	s := &bytes.Buffer{}
+
+	for {
+		r, _, err := buf.ReadRune()
+		if err != nil {
+			return "", err
+		}
+
+		switch r {
+		case '\\':
+			r, _, err = buf.ReadRune()
+			if err != nil {
+				return "", err
+			}
+		case '"':
+			r, _, err = buf.ReadRune()
+			if err != nil {
+				return "", err
+			}
+			if r != '"' {
+				buf.UnreadRune()
+				return s.String(), nil
+			}
+		}
+		s.WriteRune(r)
+	}
+}
+
+func skipWhitespace(buf *bytes.Buffer) {
+	var r rune
+	var err error
+	for r, _, _ = buf.ReadRune(); unicode.IsSpace(r); r, _, _ = buf.ReadRune() {
+	}
+
+	if err != io.EOF {
+		buf.UnreadRune()
+	}
+}

--- a/types/scan.go
+++ b/types/scan.go
@@ -232,7 +232,8 @@ func ScanTime(rd Reader, n int) (time.Time, error) {
 		return time.Time{}, err
 	}
 
-	return ParseTime(tmp)
+	t, _, err := ParseTime(tmp)
+	return t, err
 }
 
 func ScanBool(rd Reader, n int) (bool, error) {

--- a/types/time.go
+++ b/types/time.go
@@ -61,7 +61,7 @@ func (im TimeSpecialValue) String() string {
 
 func ParseTime(b []byte) (time.Time, TimeSpecialValue, error) {
 	s := internal.BytesToString(b)
-	return ParseTimeString(string(s))
+	return ParseTimeString(s)
 }
 
 func ParseTimeString(s string) (t time.Time, tsv TimeSpecialValue, err error) {

--- a/types/time.go
+++ b/types/time.go
@@ -15,33 +15,92 @@ const (
 	timestamptzFormat3 = "2006-01-02 15:04:05.999999999-07"
 )
 
-func ParseTime(b []byte) (time.Time, error) {
-	s := internal.BytesToString(b)
-	return ParseTimeString(s)
+type TimeSpecialValue int8
+
+// named awkwardly to avoid collisions without checking
+const (
+	TSVNegativeInfinity TimeSpecialValue = iota - 1
+	TSVNone
+	TSVInfinity
+	TSVEpoch
+	TSVNow
+	TSVToday
+	TSVTomorrow
+	TSVYesterday
+	TSVAllBalls
+)
+
+func (im TimeSpecialValue) Bytes() []byte {
+	return []byte(im.String())
 }
 
-func ParseTimeString(s string) (time.Time, error) {
+func (im TimeSpecialValue) String() string {
+	switch im {
+	case TSVNone:
+		return "none"
+	case TSVInfinity:
+		return "infinity"
+	case TSVNegativeInfinity:
+		return "-infinity"
+	case TSVEpoch:
+		return "epoch"
+	case TSVNow:
+		return "now"
+	case TSVToday:
+		return "today"
+	case TSVTomorrow:
+		return "tomorrow"
+	case TSVYesterday:
+		return "yesterday"
+	case TSVAllBalls:
+		return "allballs"
+	default:
+		return "invalid"
+	}
+}
+
+func ParseTime(b []byte) (time.Time, TimeSpecialValue, error) {
+	s := internal.BytesToString(b)
+	return ParseTimeString(string(s))
+}
+
+func ParseTimeString(s string) (t time.Time, tsv TimeSpecialValue, err error) {
+	if s == "-infinity" {
+		tsv = TSVNegativeInfinity
+		return
+	}
+	if s == "infinity" {
+		tsv = TSVInfinity
+		return
+	}
 	switch l := len(s); {
 	case l <= len(timeFormat):
 		if s[2] == ':' {
-			return time.ParseInLocation(timeFormat, s, time.UTC)
+			t, err = time.ParseInLocation(timeFormat, s, time.UTC)
+		} else {
+			t, err = time.ParseInLocation(dateFormat, s, time.UTC)
 		}
-		return time.ParseInLocation(dateFormat, s, time.UTC)
 	default:
 		if s[10] == 'T' {
-			return time.Parse(time.RFC3339Nano, s)
+			t, err = time.Parse(time.RFC3339Nano, s)
+			return
 		}
 		if c := s[l-9]; c == '+' || c == '-' {
-			return time.Parse(timestamptzFormat, s)
+			t, err = time.Parse(timestamptzFormat, s)
+			return
 		}
 		if c := s[l-6]; c == '+' || c == '-' {
-			return time.Parse(timestamptzFormat2, s)
+			t, err = time.Parse(timestamptzFormat2, s)
+			return
 		}
 		if c := s[l-3]; c == '+' || c == '-' {
-			return time.Parse(timestamptzFormat3, s)
+			t, err = time.Parse(timestamptzFormat3, s)
+			return
 		}
-		return time.ParseInLocation(timestampFormat, s, time.UTC)
+		t, err = time.ParseInLocation(timestampFormat, s, time.UTC)
+		return
 	}
+	return
 }
 
 func AppendTime(b []byte, tm time.Time, flags int) []byte {


### PR DESCRIPTION


This pr adds support for tstzrange data type.
The content of range.go is taken from jackc/pgtype.
Main concern:

- It modifies NullTime in a way that prevents unnamed field initialization. pg.NullTime{time.Now()} and such will no longer work.
- There are currently no tests for tstzrange, maybe somebody else wants to translate postgresql spec to test cases?

```
types.NullTimeRange{
    Lower: pg.NullTime{
        Time: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
    },
    Upper: pg.NullTime{
        Time: time.Date(2020, 12, 31, 24, 0, 0, 0, time.UTC),
    },
    LowerType: types.RBoundInclusive,
    UpperType: types.RBoundExclusive,
}

```
^ usage for a tstzrange spanning 2020

```
types.NullTimeRange{
    Lower:     pg.NullTime{Special: -types.TSVInfinity},
    Upper:     pg.NullTime{Special: types.TSVInfinity},
    LowerType: types.RBoundInclusive,
    UpperType: types.RBoundExclusive,
}
```

^ usage for a tstzrange using special timestamptz values

Maybe it is worth considering elevating some of the stuff of the types package to the pg package, just like pg.NullTime.