### PR TITLE
Add go-pg-monitor to README ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - [Genna - cli tool for generating go-pg models](https://github.com/dizzyfool/genna).
 - [urlstruct](https://github.com/go-pg/urlstruct) to decode `url.Values` into structs.
 - [Sharding](https://github.com/go-pg/sharding).
+- [go-pg-monitor](https://github.com/hypnoglow/go-pg-monitor) - Prometheus metrics based on go-pg client stats.
 
 ## Features
 


### PR DESCRIPTION
Hi! I made a package to export db client stats as Prometheus metrics. We already use it for some of our services.
If you see a fit, we can add this to README ecosystem section, maybe someone will find it useful.
Thanks.