### PR TITLE
Fix logger prefix

### DIFF
--- a/internal/log.go
+++ b/internal/log.go
@@ -24,5 +24,5 @@ func (l *logger) Printf(ctx context.Context, format string, v ...interface{}) {
 }
 
 var Logger Logging = &logger{
-	log: log.New(os.Stderr, "redis: ", log.LstdFlags|log.Lshortfile),
+	log: log.New(os.Stderr, "pg: ", log.LstdFlags|log.Lshortfile),
 }


### PR DESCRIPTION
Well, one thing I know for sure is that there is no reason we should have `redis: ` prefix in go-pg logger