### PR TITLE
(#1830) Fixed notice during startup error.

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -96,6 +96,18 @@ func TestDBString(t *testing.T) {
 	}
 }
 
+func TestDBConnectWithStartupNotice(t *testing.T) {
+	options := pgOptions()
+	// Set our application name to be too long.
+	options.ApplicationName = "i am just a really really super long application name so that i make a notice during startup"
+	db := pg.Connect(options)
+	defer db.Close()
+
+	// Upon hitting PostgreSQL we would normally receive an error if we don't handle the notice response, this will
+	// now succeed.
+	require.NoError(t, db.Ping(context.Background()), "must successfully ping database with long application name")
+}
+
 func TestOnConnect(t *testing.T) {
 	opt := pgOptions()
 	opt.OnConnect = func(ctx context.Context, db *pg.Conn) error {


### PR DESCRIPTION
This adds handling of Notice messages during startup and will log the messages for the client to see so they may take action.

Resolves #1830 