### PR TITLE
Fix otel db.system name

### DIFF
--- a/extra/pgotel/pgotel.go
+++ b/extra/pgotel/pgotel.go
@@ -83,7 +83,7 @@ func (h TracingHook) AfterQuery(ctx context.Context, evt *pg.QueryEvent) error {
 
 	attrs := make([]attribute.KeyValue, 0, 10)
 	attrs = append(attrs,
-		attribute.String("db.system", "postgres"),
+		attribute.String("db.system", "postgresql"),
 		attribute.String("db.statement", query),
 
 		attribute.String("code.function", fn),


### PR DESCRIPTION
According to the open [telemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#connection-level-attributes):

> db.system MUST be one of the following or, if none of the listed values apply, a custom value:

Down the list the name for postgres reads as "postgresql".

Add the remaining "ql" characters and conform the expectations of the spec.