### PR TITLE
orm: improve template to omits columns when there are plenty

### DIFF
--- a/orm/delete.go
+++ b/orm/delete.go
@@ -125,7 +125,7 @@ func appendColumnAndSliceValue(
 
 	b = append(b, " IN ("...)
 
-	isPlaceholder := isPlaceholderFormatter(fmter)
+	isPlaceholder := isTemplateFormatter(fmter)
 	sliceLen := slice.Len()
 	for i := 0; i < sliceLen; i++ {
 		if i > 0 {

--- a/orm/format.go
+++ b/orm/format.go
@@ -127,12 +127,9 @@ func (f dummyFormatter) FormatQuery(b []byte, query string, params ...interface{
 	return append(b, query...)
 }
 
-func isPlaceholderFormatter(fmter QueryFormatter) bool {
-	if fmter == nil {
-		return false
-	}
-	b := fmter.FormatQuery(nil, "?", 0)
-	return bytes.Equal(b, []byte("?"))
+func isTemplateFormatter(fmter QueryFormatter) bool {
+	_, ok := fmter.(dummyFormatter)
+	return ok
 }
 
 //------------------------------------------------------------------------------

--- a/orm/query.go
+++ b/orm/query.go
@@ -1575,7 +1575,7 @@ func (q wherePKStructQuery) AppendQuery(fmter QueryFormatter, b []byte) ([]byte,
 func appendColumnAndValue(
 	fmter QueryFormatter, b []byte, v reflect.Value, alias types.Safe, fields []*Field,
 ) []byte {
-	isPlaceholder := isPlaceholderFormatter(fmter)
+	isPlaceholder := isTemplateFormatter(fmter)
 	for i, f := range fields {
 		if i > 0 {
 			b = append(b, " AND "...)

--- a/orm/select.go
+++ b/orm/select.go
@@ -2,8 +2,11 @@ package orm
 
 import (
 	"bytes"
+	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/go-pg/pg/v10/types"
 )
 
 type SelectQuery struct {
@@ -219,7 +222,13 @@ func (q SelectQuery) appendColumns(fmter QueryFormatter, b []byte) (_ []byte, er
 		}
 	case q.q.hasExplicitTableModel():
 		table := q.q.tableModel.Table()
-		b = appendColumns(b, table.Alias, table.Fields)
+		if len(table.Fields) > 10 && isTemplateFormatter(fmter) {
+			b = append(b, table.Alias...)
+			b = append(b, '.')
+			b = types.AppendString(b, fmt.Sprintf("%d columns", len(table.Fields)), 2)
+		} else {
+			b = appendColumns(b, table.Alias, table.Fields)
+		}
 	default:
 		b = append(b, '*')
 	}

--- a/orm/select_test.go
+++ b/orm/select_test.go
@@ -1,11 +1,13 @@
 package orm
 
 import (
+	"testing"
 	"time"
 
 	"github.com/go-pg/pg/v10/types"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
 )
 
 type User struct {
@@ -497,9 +499,32 @@ func selectQueryString(q *Query) string {
 	return s
 }
 
-func queryString(f QueryAppender) string {
-	fmter := NewFormatter().WithModel(f)
-	b, err := f.AppendQuery(fmter, nil)
+func queryString(model QueryAppender) string {
+	fmter := NewFormatter().WithModel(model)
+	b, err := model.AppendQuery(fmter, nil)
 	Expect(err).NotTo(HaveOccurred())
 	return string(b)
+}
+
+func TestLongSelectFormatter(t *testing.T) {
+	type Model struct {
+		A1  int
+		A2  int
+		A3  int
+		A4  int
+		A5  int
+		A6  int
+		A7  int
+		A8  int
+		A9  int
+		A10 int
+		A11 int
+	}
+
+	q := NewQuery(nil, &Model{})
+	sel := NewSelectQuery(q)
+
+	b, err := sel.AppendTemplate(nil)
+	require.NoError(t, err)
+	require.Equal(t, `SELECT "model"."11 columns" FROM "models" AS "model"`, string(b))
 }


### PR DESCRIPTION
When a model has >10 columns template formatter prints number of columns instead of huge list:

```sql
SELECT "model"."11 columns" FROM "models" AS "model"
```