### PR TITLE
Fix relation example docs.

### DIFF
--- a/example_model_test.go
+++ b/example_model_test.go
@@ -581,10 +581,9 @@ func ExampleDB_Model_hasOne() {
 	// SELECT
 	//   "user".*,
 	//   "profile"."id" AS "profile__id",
-	//   "profile"."lang" AS "profile__lang",
-	//   "profile"."user_id" AS "profile__user_id"
+	//   "profile"."lang" AS "profile__lang"
 	// FROM "users" AS "user"
-	// LEFT JOIN "profiles" AS "profile" ON "profile"."user_id" = "user"."id"
+	// LEFT JOIN "profiles" AS "profile" ON "profile"."id" = "user"."profile_id"
 
 	var users []User
 	err := db.Model(&users).
@@ -638,9 +637,10 @@ func ExampleDB_Model_belongsTo() {
 	// SELECT
 	//   "user".*,
 	//   "profile"."id" AS "profile__id",
-	//   "profile"."lang" AS "profile__lang"
+	//   "profile"."lang" AS "profile__lang",
+	//   "profile"."user_id" AS "profile__user_id"
 	// FROM "users" AS "user"
-	// LEFT JOIN "profiles" AS "profile" ON "profile"."id" = "user"."profile_id"
+	// LEFT JOIN "profiles" AS "profile" ON "profile"."user_id" = "user"."id"
 
 	var users []User
 	err := db.Model(&users).


### PR DESCRIPTION
ExampleDB_Model_hasOne and ExampleDB_Model_belongsTo functions contain confused SQL queries for relation examples.