### PR TITLE
fix: Add `-race` flag to GitHub actions test workflow.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all:
 
 .PHONY: test
 test:
-	TZ= PGSSLMODE=disable go test ./... -v
+	TZ= PGSSLMODE=disable go test ./... -v -race
 
 tag:
 	git tag $(VERSION)


### PR DESCRIPTION
Added `-race` to the `test` target in the Makefile, this way tests that
are run in GitHub Actions will help reveal any potential race
conditions.