### PR TITLE
fix: Fixed `NULL` not being formatted for slices/maps.

### DIFF
--- a/types/append_value.go
+++ b/types/append_value.go
@@ -132,8 +132,14 @@ func ptrAppenderFunc(typ reflect.Type) AppenderFunc {
 }
 
 func appendValue(b []byte, v reflect.Value, flags int) []byte {
-	if v.Kind() == reflect.Ptr && v.IsNil() {
-		return AppendNull(b, flags)
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Slice, reflect.Map:
+		// When the value is a pointer, slice or map; then we can assert if the value provided is nil.
+		// When the value is properly nil; then we can append NULL instead of a string representation of the provided
+		// value.
+		if v.IsNil() {
+			return AppendNull(b, flags)
+		}
 	}
 	appender := Appender(v.Type())
 	return appender(b, v, flags)

--- a/types/append_value_test.go
+++ b/types/append_value_test.go
@@ -1,0 +1,27 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppend(t *testing.T) {
+	t.Run("null pointer", func(t *testing.T) {
+		var a *struct{}
+		result := Append(nil, a, 1)
+		assert.Equal(t, "NULL", string(result))
+	})
+
+	t.Run("null map", func(t *testing.T) {
+		var a map[string]int
+		result := Append(nil, a, 1)
+		assert.Equal(t, "NULL", string(result))
+	})
+
+	t.Run("null string array", func(t *testing.T) {
+		var a []string
+		result := Append(nil, a, 1)
+		assert.Equal(t, "NULL", string(result))
+	})
+}


### PR DESCRIPTION
When a query parameter was a nil slice or a nil map, the value `NULL`
would not be appended to the query. Instead `'null'` would be appended
to the query which is not correct.

Resolves #1908