### PR TITLE
Fix hook

### DIFF
--- a/extra/pgdebug/pgdebug.go
+++ b/extra/pgdebug/pgdebug.go
@@ -23,7 +23,7 @@ func NewDebugHook() *DebugHook {
 
 var _ pg.QueryHook = (*DebugHook)(nil)
 
-func (h *DebugHook) BeforeQuery(ctx context.Context, evt *pg.QueryEvent) (context.Context, error) {
+func (h DebugHook) BeforeQuery(ctx context.Context, evt *pg.QueryEvent) (context.Context, error) {
 	q, err := evt.FormattedQuery()
 	if err != nil {
 		return nil, err

--- a/extra/pgotel/pgotel.go
+++ b/extra/pgotel/pgotel.go
@@ -29,7 +29,7 @@ func NewTracingHook() *TracingHook {
 
 var _ pg.QueryHook = (*TracingHook)(nil)
 
-func (h *TracingHook) BeforeQuery(ctx context.Context, _ *pg.QueryEvent) (context.Context, error) {
+func (h TracingHook) BeforeQuery(ctx context.Context, _ *pg.QueryEvent) (context.Context, error) {
 	if !trace.SpanFromContext(ctx).IsRecording() {
 		return ctx, nil
 	}
@@ -38,7 +38,7 @@ func (h *TracingHook) BeforeQuery(ctx context.Context, _ *pg.QueryEvent) (contex
 	return ctx, nil
 }
 
-func (h *TracingHook) AfterQuery(ctx context.Context, evt *pg.QueryEvent) error {
+func (h TracingHook) AfterQuery(ctx context.Context, evt *pg.QueryEvent) error {
 	const (
 		softQueryLimit = 5000
 		hardQueryLimit = 10000


### PR DESCRIPTION
With the current version, I have those errors when trying to use the
hook:
```
cannot use pgdebug.DebugHook{...} (type pgdebug.DebugHook) as type pg.QueryHook in argument to db.baseDB.AddQueryHook:
pgdebug.DebugHook does not implement pg.QueryHook (BeforeQuery method has pointer receiver)
```

```
cannot use pgotel.TracingHook{} (type pgotel.TracingHook) as type pg.QueryHook in argument to db.baseDB.AddQueryHook:
pgotel.TracingHook does not implement pg.QueryHook (AfterQuery method has pointer receiver)
```