### PR TITLE
Add shortcut WhereInOr

### DIFF
--- a/orm/query.go
+++ b/orm/query.go
@@ -570,6 +570,11 @@ func (q *Query) WhereIn(where string, slice interface{}) *Query {
 	return q.Where(where, types.In(slice))
 }
 
+// WhereInOr is a shortcut for WhereOr and pg.In.
+func (q *Query) WhereInOr(where string, slice interface{}) *Query {
+	return q.WhereOr(where, types.In(slice))
+}
+
 // WhereInMulti is a shortcut for Where and pg.InMulti.
 func (q *Query) WhereInMulti(where string, values ...interface{}) *Query {
 	return q.Where(where, types.InMulti(values...))

--- a/orm/select_test.go
+++ b/orm/select_test.go
@@ -239,6 +239,15 @@ var _ = Describe("Select", func() {
 		Expect(s).To(Equal(`SELECT * WHERE (id IN ('foo','bar'))`))
 	})
 
+	It("supports WhereInOr", func() {
+		q := NewQuery(nil).
+			WhereIn("id IN (?)", []string{"foo", "bar"}).
+			WhereInOr("name IN (?)", []string{"foo", "bar"})
+
+		s := selectQueryString(q)
+		Expect(s).To(Equal(`SELECT * WHERE (id IN ('foo','bar')) OR (name IN ('foo','bar'))`))
+	})
+
 	It("supports Where & pg.In", func() {
 		q := NewQuery(nil).
 			Where("id IN (?)", types.In([]string{"foo", "bar"}))

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package pg
 
 // Version is the current release version.
 func Version() string {
-	return "10.10.7"
+	return "10.10.8"
 }

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package pg
 
 // Version is the current release version.
 func Version() string {
-	return "10.10.8"
+	return "10.10.6"
 }

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package pg
 
 // Version is the current release version.
 func Version() string {
-	return "10.10.6"
+	return "10.10.7"
 }


### PR DESCRIPTION
A shortcut is proposed for implementing a query to the database, for example, SELECT * WHERE column 1 in the slice or column 2 in the slice