### PR TITLE
fix buff size comparison & proper error message

### DIFF
--- a/types/scan.go
+++ b/types/scan.go
@@ -107,8 +107,8 @@ func ReadBytes(rd Reader, b []byte) error {
 	}
 	tmp = tmp[2:] // Trim off "\\x".
 
-	if len(b) != hex.DecodedLen(len(tmp)) {
-		return fmt.Errorf("pg: too small buf to decode hex")
+	if len(b) < hex.DecodedLen(len(tmp)) {
+		return fmt.Errorf("pg: too small buf to decode hex, src: %d, dest %d", hex.DecodedLen(len(tmp)), len(b))
 	}
 
 	if _, err := hex.Decode(b, tmp); err != nil {


### PR DESCRIPTION
When scanning a byte column `ReadBytes` expect to have exact size of a `[]byte` We should be able to read bytes into a buffer that is bigger than our data size in this column. This cause errors when you have a fixed field size in code but variable size in database. The error message was also misleading like it was checking if we have enough space but it actually expect to have exact size. So, changed the comparison to accept bigger buffers and to properly print the source & destination buffer size. 
