### PR TITLE
Fix a bug for sending cancel request to terminate a long running query

### DIFF
--- a/base.go
+++ b/base.go
@@ -190,8 +190,8 @@ func (db *baseDB) shouldRetry(err error) bool {
 			"53300", // too_many_connections
 			"55000": // attempted to delete invisible tuple
 			return true
-		case "57014": // statement_timeout
-			return db.opt.RetryStatementTimeout
+		case "57014": // query_canceled
+			return db.opt.RetryCancelledQuery
 		default:
 			return false
 		}

--- a/base.go
+++ b/base.go
@@ -146,17 +146,15 @@ func (db *baseDB) withConn(
 	if ctx != nil && ctx.Done() != nil {
 		fnDone = make(chan struct{})
 		go func() {
-			for {
-				select {
-				case <-fnDone: // fn has finished, skip cancel
-				case <-ctx.Done():
-					err := db.cancelRequest(cn.ProcessID, cn.SecretKey)
-					if err != nil {
-						internal.Logger.Printf(ctx, "cancelRequest failed: %s", err)
-					}
-					// Signal end of conn use.
-					fnDone <- struct{}{}
+			select {
+			case <-fnDone: // fn has finished, skip cancel
+			case <-ctx.Done():
+				err := db.cancelRequest(cn.ProcessID, cn.SecretKey)
+				if err != nil {
+					internal.Logger.Printf(ctx, "cancelRequest failed: %s", err)
 				}
+				// Signal end of conn use.
+				fnDone <- struct{}{}
 			}
 		}()
 	}

--- a/base.go
+++ b/base.go
@@ -124,7 +124,7 @@ func (db *baseDB) initConn(ctx context.Context, cn *pool.Conn) error {
 
 func (db *baseDB) releaseConn(ctx context.Context, cn *pool.Conn, err error) {
 	if bad, code := isBadConn(err, false); bad {
-		if code == "57014" { // canceling statement due to user request
+		if code != "25P02" { // canceling statement if it is a bad conn expect 25P02 (current transaction is aborted)
 			err := db.cancelRequest(cn.ProcessID, cn.SecretKey)
 			if err != nil {
 				internal.Logger.Printf(ctx, "cancelRequest failed: %s", err)

--- a/base.go
+++ b/base.go
@@ -124,6 +124,10 @@ func (db *baseDB) initConn(ctx context.Context, cn *pool.Conn) error {
 
 func (db *baseDB) releaseConn(ctx context.Context, cn *pool.Conn, err error) {
 	if isBadConn(err, false) {
+		err := db.cancelRequest(cn.ProcessID, cn.SecretKey)
+		if err != nil {
+			internal.Logger.Printf(ctx, "cancelRequest failed: %s", err)
+		}
 		db.pool.Remove(ctx, cn, err)
 	} else {
 		db.pool.Put(ctx, cn)

--- a/base.go
+++ b/base.go
@@ -192,7 +192,7 @@ func (db *baseDB) shouldRetry(err error) bool {
 			"53300", // too_many_connections
 			"55000": // attempted to delete invisible tuple
 			return true
-		case "57014": // query_canceled
+		case "57014": // statement_timeout
 			return db.opt.RetryStatementTimeout
 		default:
 			return false

--- a/base.go
+++ b/base.go
@@ -195,7 +195,7 @@ func (db *baseDB) shouldRetry(err error) bool {
 			"55000": // attempted to delete invisible tuple
 			return true
 		case "57014": // query_canceled
-			return db.opt.RetryCancelledQuery
+			return db.opt.RetryStatementTimeout
 		default:
 			return false
 		}

--- a/base_test.go
+++ b/base_test.go
@@ -1,0 +1,137 @@
+package pg
+
+import (
+	"context"
+	"encoding/binary"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/go-pg/pg/v10/internal/pool"
+	"github.com/stretchr/testify/assert"
+)
+
+/*
+	The test is for testing the case that sending a cancel request when the timeout from connection comes earlier than ctx.Done().
+*/
+func Test_baseDB_withConn(t *testing.T) {
+	b := mockBaseDB{}
+	b.init()
+	b.pool = &mockPooler{}
+	ctx, _ := context.WithDeadline(context.TODO(), time.Now().Add(1000*time.Second)) // Make a deadline in context further than the timeout of connection.
+	b.withConn(ctx, func(context.Context, *pool.Conn) error {
+		// Immediately returns the error, so it is faster than the ctx.Done() returns. The error code here according to the function `isBadConn`.
+		return &mockPGError{map[byte]string{byte('C'): "57014"}}
+	})
+	// In the new change, a cancel request is sent to db and that connection is removed from the connection pool.
+	// Check if the cancel request, its code int32(80877102), is sent.
+	assert.Equal(t, int32(80877102), b.pool.(*mockPooler).mockConn.cancelCode)
+	assert.True(t, b.pool.(*mockPooler).toRemove)
+}
+
+type mockBaseDB struct {
+	baseDB
+}
+
+func (m *mockBaseDB) init() {
+	m.opt = &Options{}
+}
+
+type mockPooler struct {
+	conn     *pool.Conn
+	toRemove bool
+	mockConn mockConn
+}
+
+func (m *mockPooler) NewConn(ctx context.Context) (*pool.Conn, error) {
+	m.conn = &pool.Conn{ProcessID: 123, SecretKey: 234, Inited: true}
+	m.mockConn = mockConn{}
+	m.conn.SetNetConn(&m.mockConn)
+	return m.conn, nil
+}
+
+func (m *mockPooler) CloseConn(conn *pool.Conn) error {
+	return nil
+}
+
+func (m *mockPooler) Get(ctx context.Context) (*pool.Conn, error) {
+	return &pool.Conn{ProcessID: 123, SecretKey: 234, Inited: true}, nil
+}
+
+func (m *mockPooler) Put(ctx context.Context, conn *pool.Conn) {
+	return
+}
+
+func (m *mockPooler) Remove(ctx context.Context, conn *pool.Conn, err error) {
+	m.toRemove = true
+	return
+}
+
+func (m *mockPooler) Len() int {
+	return 1
+}
+
+func (m *mockPooler) IdleLen() int {
+	return 1
+}
+
+func (m *mockPooler) Stats() *pool.Stats {
+	return nil
+}
+
+func (m *mockPooler) Close() error {
+	return nil
+}
+
+type mockPGError struct {
+	M map[byte]string
+}
+
+func (m *mockPGError) Error() string {
+	return ""
+}
+
+func (m *mockPGError) Field(field byte) string {
+	return m.M[field]
+}
+
+func (m *mockPGError) IntegrityViolation() bool {
+	return false
+}
+
+type mockConn struct {
+	cancelCode int32
+}
+
+func (m *mockConn) Read(b []byte) (n int, err error) {
+	return 0, nil
+}
+
+func (m *mockConn) Write(b []byte) (n int, err error) {
+	m.cancelCode = int32(binary.BigEndian.Uint32(b[4:8]))
+	return 0, nil
+}
+
+func (m *mockConn) Close() error {
+	return nil
+}
+
+func (m *mockConn) LocalAddr() net.Addr {
+	return nil
+}
+
+func (m *mockConn) RemoteAddr() net.Addr {
+	return nil
+}
+
+func (m *mockConn) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (m *mockConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (m *mockConn) SetWriteDeadline(t time.Time) error {
+	return nil
+}

--- a/listener.go
+++ b/listener.go
@@ -110,7 +110,7 @@ func (ln *Listener) conn(ctx context.Context) (*pool.Conn, error) {
 func (ln *Listener) releaseConn(ctx context.Context, cn *pool.Conn, err error, allowTimeout bool) {
 	ln.mu.Lock()
 	if ln.cn == cn {
-		if isBadConn(err, allowTimeout) {
+		if bad, _ := isBadConn(err, allowTimeout); bad {
 			ln.reconnect(ctx, err)
 		}
 	}

--- a/options.go
+++ b/options.go
@@ -58,7 +58,7 @@ type Options struct {
 	// Default is to not retry failed queries.
 	MaxRetries int
 	// Whether to retry queries cancelled because of statement_timeout or cancel request.
-	RetryCancelledQuery bool
+	RetryStatementTimeout bool
 	// Minimum backoff between each retry.
 	// Default is 250 milliseconds; -1 disables backoff.
 	MinRetryBackoff time.Duration

--- a/options.go
+++ b/options.go
@@ -57,8 +57,8 @@ type Options struct {
 	// Maximum number of retries before giving up.
 	// Default is to not retry failed queries.
 	MaxRetries int
-	// Whether to retry queries cancelled because of statement_timeout.
-	RetryStatementTimeout bool
+	// Whether to retry queries cancelled because of statement_timeout or cancel request.
+	RetryCancelledQuery bool
 	// Minimum backoff between each retry.
 	// Default is 250 milliseconds; -1 disables backoff.
 	MinRetryBackoff time.Duration

--- a/options.go
+++ b/options.go
@@ -57,7 +57,7 @@ type Options struct {
 	// Maximum number of retries before giving up.
 	// Default is to not retry failed queries.
 	MaxRetries int
-	// Whether to retry queries cancelled because of statement_timeout or cancel request.
+	// Whether to retry queries cancelled because of statement_timeout.
 	RetryStatementTimeout bool
 	// Minimum backoff between each retry.
 	// Default is 250 milliseconds; -1 disables backoff.


### PR DESCRIPTION
Hi All,

Update:
The issue this PR tries to solve is that we observed some long running queries did not get cancelled.

~Changes in the PR:~
~1. Fix a bug for sending cancel request to terminate a long running query~
~2. Update a var name `RetryStatementTimeout` to `RetryCancelledQuery`,~
~reference:https://www.postgresql.org/docs/current/errcodes-appendix.html~
~In the table, 57014 is query_canceled.~
~During a local experiment, the query which is cancelled by sending cancel request also returns 57014.~




