### PR TITLE
fix(notify): Fixed race condition in listener.

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -185,9 +185,11 @@ func (ln *Listener) listen(ctx context.Context, cn *pool.Conn, channels ...strin
 func (ln *Listener) Unlisten(ctx context.Context, channels ...string) error {
 	ln.mu.Lock()
 	ln.channels = removeIfExists(ln.channels, channels...)
-	ln.mu.Unlock()
 
 	cn, err := ln.conn(ctx)
+	// I don't want to defer this unlock as the mutex is re-acquired in the `.releaseConn` function. But it is safe to
+	// unlock here regardless of an error.
+	ln.mu.Unlock()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This resolves a race condition in listener where `ln.closed` was being
read without a mutex at the same time it could be written. Just move the
mutex unlock for `Unlisten` down, **but not defer it** so that the mutex
still holds the lock properly. But does not cause a deadlock with
release conn.

```
==================
    testing.go:1319: race detected during execution of test
WARNING: DATA RACE
Write at 0x00c000614098 by goroutine 38:
  github.com/go-pg/pg/v10.(*Listener).Close()
      /Users/elliotcourant/go/pkg/mod/github.com/go-pg/pg/v10@v10.10.6/listener.go:146 +0x128
  github.com/go-pg/pg/v10.(*Listener).connWithLock()
      /Users/elliotcourant/go/pkg/mod/github.com/go-pg/pg/v10@v10.10.6/listener.go:69 +0x219
  github.com/go-pg/pg/v10.(*Listener).ReceiveTimeout()
      /Users/elliotcourant/go/pkg/mod/github.com/go-pg/pg/v10@v10.10.6/listener.go:226 +0x7b
  github.com/go-pg/pg/v10.(*Listener).Receive()
      /Users/elliotcourant/go/pkg/mod/github.com/go-pg/pg/v10@v10.10.6/listener.go:218 +0xd3
  github.com/go-pg/pg/v10.(*Listener).initChannel.func1()
      /Users/elliotcourant/go/pkg/mod/github.com/go-pg/pg/v10@v10.10.6/listener.go:285 +0x3d2

Previous read at 0x00c000614098 by goroutine 36:
  github.com/go-pg/pg/v10.(*Listener).conn()
      /Users/elliotcourant/go/pkg/mod/github.com/go-pg/pg/v10@v10.10.6/listener.go:78 +0x64
  github.com/go-pg/pg/v10.(*Listener).Unlisten()
      /Users/elliotcourant/go/pkg/mod/github.com/go-pg/pg/v10@v10.10.6/listener.go:190 +0x166

Goroutine 38 (running) created at:
  github.com/go-pg/pg/v10.(*Listener).initChannel()
      /Users/elliotcourant/go/pkg/mod/github.com/go-pg/pg/v10@v10.10.6/listener.go:279 +0x23a
  github.com/go-pg/pg/v10.(*Listener).channel.func1()
      /Users/elliotcourant/go/pkg/mod/github.com/go-pg/pg/v10@v10.10.6/listener.go:260 +0x3e
  sync.(*Once).doSlow()
      /usr/local/opt/go/libexec/src/sync/once.go:74 +0x101
  sync.(*Once).Do()
      /usr/local/opt/go/libexec/src/sync/once.go:65 +0x46
  github.com/go-pg/pg/v10.(*Listener).channel()
      /Users/elliotcourant/go/pkg/mod/github.com/go-pg/pg/v10@v10.10.6/listener.go:259 +0x6d
  github.com/go-pg/pg/v10.(*Listener).Channel()
      /Users/elliotcourant/go/pkg/mod/github.com/go-pg/pg/v10@v10.10.6/listener.go:249 +0x71

Goroutine 36 (running) created at:
  github.com/monetr/monetr/pkg/pubsub.(*postgresPubSub).Subscribe()
      /Users/elliotcourant/monetr/monetr/pkg/pubsub/pubsub.go:84 +0x664
```
