### PR TITLE
Update err for single conn pool when context.Done() return first

### DIFF
--- a/internal/pool/pool_single.go
+++ b/internal/pool/pool_single.go
@@ -37,6 +37,9 @@ func (p *SingleConnPool) Put(ctx context.Context, cn *Conn) {}
 func (p *SingleConnPool) Remove(ctx context.Context, cn *Conn, reason error) {
 	p.cn = nil
 	p.stickyErr = reason
+	if reason == nil && ctx != nil {
+		p.stickyErr = ctx.Err()
+	}
 }
 
 func (p *SingleConnPool) Close() error {

--- a/internal/pool/pool_single.go
+++ b/internal/pool/pool_single.go
@@ -37,6 +37,8 @@ func (p *SingleConnPool) Put(ctx context.Context, cn *Conn) {}
 func (p *SingleConnPool) Remove(ctx context.Context, cn *Conn, reason error) {
 	p.cn = nil
 	p.stickyErr = reason
+	// If ctx is cancelled without a reason(error) value,
+	// then the ctx.Error is used as the reason for why the p.cn is assigned nil.
 	if reason == nil && ctx != nil {
 		p.stickyErr = ctx.Err()
 	}

--- a/internal/pool/pool_single_test.go
+++ b/internal/pool/pool_single_test.go
@@ -11,12 +11,12 @@ import (
 var _ = Describe("SingleConnPool", func() {
 	It("remove a conn due to context is cancelled", func() {
 		p := pool.NewSingleConnPool(nil, &pool.Conn{})
-		ctx, cl := context.WithCancel(context.TODO())
+		ctx, cancel := context.WithCancel(context.TODO())
 		cn, err := p.Get(nil)
 		Expect(err).To(BeNil())
 		Expect(cn).ToNot(BeNil())
 
-		cl()
+		cancel()
 		p.Remove(ctx, cn, nil)
 		cn, err = p.Get(nil)
 		Expect(cn).To(BeNil())

--- a/internal/pool/pool_single_test.go
+++ b/internal/pool/pool_single_test.go
@@ -1,0 +1,31 @@
+package pool_test
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/go-pg/pg/v10/internal/pool"
+)
+
+var _ = Describe("SingleConnPool", func() {
+	var p *pool.SingleConnPool
+
+	BeforeEach(func() {
+		p = pool.NewSingleConnPool(nil, &pool.Conn{})
+	})
+
+	It("remove a conn due to context is cancelled", func() {
+		ctx, cl := context.WithCancel(context.TODO())
+		cn, err := p.Get(nil)
+		Expect(err).To(BeNil())
+		Expect(cn).ToNot(BeNil())
+
+		cl()
+		p.Remove(ctx, cn, nil)
+		cn, err = p.Get(nil)
+		Expect(cn).To(BeNil())
+		Expect(err).ToNot(BeNil())
+	})
+
+})

--- a/internal/pool/pool_single_test.go
+++ b/internal/pool/pool_single_test.go
@@ -9,13 +9,8 @@ import (
 )
 
 var _ = Describe("SingleConnPool", func() {
-	var p *pool.SingleConnPool
-
-	BeforeEach(func() {
-		p = pool.NewSingleConnPool(nil, &pool.Conn{})
-	})
-
 	It("remove a conn due to context is cancelled", func() {
+		p := pool.NewSingleConnPool(nil, &pool.Conn{})
 		ctx, cl := context.WithCancel(context.TODO())
 		cn, err := p.Get(nil)
 		Expect(err).To(BeNil())
@@ -27,5 +22,4 @@ var _ = Describe("SingleConnPool", func() {
 		Expect(cn).To(BeNil())
 		Expect(err).ToNot(BeNil())
 	})
-
 })


### PR DESCRIPTION
Hi All,
The issue this PR tries to solve is that we observed an NPE in `OnConnect` method 
 https://github.com/go-pg/pg/blob/f7e1c98fed3044ae4e195a0e063f69185fb1885b/base.go#L119
when we call `conn.Exec()` twice inside the `OnConnect` method. and the second call (`conn.Exec()`) may get an `nil` conn object and fails to call `conn.Exec()`[panic].

The data flow diagram depicts how the conn is `nil` in some case:
![ctxcancelledsingleconnpool drawio](https://github.com/go-pg/pg/assets/107882527/689e6b62-212d-4b38-acf5-b297fed1d8eb)

If `ctx` gets cancelled and returns before query finishes (Yellow line in the diagram), the `conn` in `SingleConnPool` will call `Remove` method to set the conn to `nil`:
https://github.com/go-pg/pg/blob/f7e1c98fed3044ae4e195a0e063f69185fb1885b/internal/pool/pool_single.go#L38
and as well to set an error with reason, which is `nil` since it is due to `ctx` gets cancelled without an error:
https://github.com/go-pg/pg/blob/f7e1c98fed3044ae4e195a0e063f69185fb1885b/internal/pool/pool_single.go#L39

When `ctx` is cancelled:
https://github.com/go-pg/pg/blob/f7e1c98fed3044ae4e195a0e063f69185fb1885b/base.go#L153
and send `struct{}{}` to fnDone:
https://github.com/go-pg/pg/blob/f7e1c98fed3044ae4e195a0e063f69185fb1885b/base.go#L159







