### PR TITLE
fix: invalid pointer deref in pgotel instrumentation

### DIFF
--- a/extra/pgotel/pgotel.go
+++ b/extra/pgotel/pgotel.go
@@ -126,7 +126,7 @@ func (h *TracingHook) AfterQuery(ctx context.Context, evt *pg.QueryEvent) error 
 			span.RecordError(evt.Err)
 			span.SetStatus(codes.Error, evt.Err.Error())
 		}
-	} else if evt.Result != nil && (reflect.ValueOf(evt.Result).Kind() != reflect.Ptr || !reflect.ValueOf(evt.Result).IsNil()) {
+	} else if hasResults(evt) {
 		numRow := evt.Result.RowsAffected()
 		if numRow == 0 {
 			numRow = evt.Result.RowsReturned()
@@ -137,6 +137,10 @@ func (h *TracingHook) AfterQuery(ctx context.Context, evt *pg.QueryEvent) error 
 	span.SetAttributes(attrs...)
 
 	return nil
+}
+
+func hasResults(evt *pg.QueryEvent) bool {
+	return evt.Result != nil && (reflect.ValueOf(evt.Result).Kind() != reflect.Ptr || !reflect.ValueOf(evt.Result).IsNil())
 }
 
 func funcFileLine(pkg string) (string, string, int) {

--- a/extra/pgotel/pgotel.go
+++ b/extra/pgotel/pgotel.go
@@ -2,6 +2,7 @@ package pgotel
 
 import (
 	"context"
+	"reflect"
 	"runtime"
 	"strings"
 
@@ -125,7 +126,7 @@ func (h *TracingHook) AfterQuery(ctx context.Context, evt *pg.QueryEvent) error 
 			span.RecordError(evt.Err)
 			span.SetStatus(codes.Error, evt.Err.Error())
 		}
-	} else if evt.Result != nil {
+	} else if evt.Result != nil && (reflect.ValueOf(evt.Result).Kind() != reflect.Ptr || !reflect.ValueOf(evt.Result).IsNil()) {
 		numRow := evt.Result.RowsAffected()
 		if numRow == 0 {
 			numRow = evt.Result.RowsReturned()

--- a/extra/pgotel/pgotel_test.go
+++ b/extra/pgotel/pgotel_test.go
@@ -1,0 +1,62 @@
+package pgotel
+
+import (
+	"testing"
+
+	"github.com/go-pg/pg/v10"
+	"github.com/go-pg/pg/v10/orm"
+)
+
+// mockResult is a mock implementation of the Result interface
+type mockResult struct {
+	model        orm.Model
+	rowsAffected int
+	rowsReturned int
+}
+
+func (m mockResult) Model() orm.Model {
+	return m.model
+}
+
+func (m mockResult) RowsAffected() int {
+	return m.rowsAffected
+}
+
+func (m mockResult) RowsReturned() int {
+	return m.rowsReturned
+}
+
+func TestHasResults(t *testing.T) {
+	// Define test cases
+	testCases := []struct {
+		name     string
+		event    *pg.QueryEvent
+		expected bool
+	}{
+		{
+			name:     "Nil Result",
+			event:    &pg.QueryEvent{Result: nil},
+			expected: false,
+		},
+		{
+			name:     "Nil Pointer Result",
+			event:    &pg.QueryEvent{Result: (*mockResult)(nil)},
+			expected: false,
+		},
+		{
+			name:     "Non-Nil Result",
+			event:    &pg.QueryEvent{Result: mockResult{rowsAffected: 1, rowsReturned: 1}},
+			expected: true,
+		},
+	}
+
+	// Run test cases
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := hasResults(tc.event)
+			if result != tc.expected {
+				t.Errorf("hasResults(%v) = %v, want %v", tc.event, result, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We've been experiencing panics on production code with a stack trace like this:
```
panic runtime error: invalid memory address or nil pointer dereference [recovered] 
    go.opentelemetry.io/otel/sdk/trace/span.go:383 (*recordingSpan).End.func1
    go.opentelemetry.io/otel/sdk/trace/span.go:421 (*recordingSpan).End
    /usr/local/go/src/runtime/panic.go:914 panic
    github.com/go-pg/pg/v10/result.go:48 (*result).RowsAffected
    github.com/go-pg/pg/extra/pgotel/v10/pgotel.go:129 (*TracingHook).AfterQuery
    github.com/go-pg/pg/v10/hook.go:130 (*baseDB).afterQueryFromIndex
    github.com/go-pg/pg/v10/hook.go:125 (*baseDB).afterQuery
    github.com/go-pg/pg/v10/tx.go:238 (*Tx).query
    github.com/go-pg/pg/v10/tx.go:211 (*Tx).QueryContext
    github.com/go-pg/pg/v10/orm/query.go:1163 (*Query).returningQuery
    github.com/go-pg/pg/v10/orm/query.go:1034 (*Query).Insert
```

We noticed that, while there's a nil guard on evt.Result, we also need to check that, when result implementation is filled with a pointer that pointer is not nil.

I've written a similar example of this issue on https://go.dev/play/p/mVBQkMv7lJU
