### PR TITLE
Add password environment variable for customizing running tests

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -14,12 +14,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-pg/pg/v10"
+	"github.com/go-pg/pg/v10/orm"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/stretchr/testify/require"
-
-	"github.com/go-pg/pg/v10"
-	"github.com/go-pg/pg/v10/orm"
 )
 
 func init() {
@@ -34,8 +33,6 @@ func TestGinkgo(t *testing.T) {
 
 func pgOptions() *pg.Options {
 	return &pg.Options{
-		User:      "postgres",
-		Password:  "postgres",
 		TLSConfig: getTLSConfig(),
 
 		MaxRetries:      1,

--- a/options.go
+++ b/options.go
@@ -125,6 +125,10 @@ func (opt *Options) init() {
 		opt.User = env("PGUSER", "postgres")
 	}
 
+	if opt.Password == "" {
+		opt.Password = env("PGPASSWORD", "postgres")
+	}
+
 	if opt.Database == "" {
 		opt.Database = env("PGDATABASE", "postgres")
 	}


### PR DESCRIPTION
In #1429, environment variables were added to read in postgres connection details for customizing tests. This change does the same but with a password variable.

It also removes the explicit user and password values from pgOptions, as Options init() will set it as postgres anyway if not specified. This also enables env variables to be used instead for those values.