### PR TITLE
Update pgutil_test.go

### DIFF
--- a/pgutil/pgutil_test.go
+++ b/pgutil/pgutil_test.go
@@ -3,7 +3,7 @@ package pgutil_test
 import (
 	"testing"
 
-	"github.com/go-pg/pg/pgutil"
+	"gopkg.in/pg.v3/pgutil"
 )
 
 func TestUnderscore(t *testing.T) {


### PR DESCRIPTION
Fix import of pgutil to prevent error. As of now it causes the following error:








```
       [gopkg.in/pg.v3](http://gopkg.in/pg.v3) imports

	[gopkg.in/pg.v3/pgutil](http://gopkg.in/pg.v3/pgutil) tested by

	[gopkg.in/pg.v3/pgutil.test](http://gopkg.in/pg.v3/pgutil.test) imports

	[github.com/go-pg/pg/pgutil](http://github.com/go-pg/pg/pgutil): module [github.com/go-pg/pg@latest](http://github.com/go-pg/pg@latest) found (v8.0.7+incompatible), but does not contain package [github.com/go-pg/pg/pgutil](http://github.com/go-pg/pg/pgutil)

```