### PR TITLE
add mandatory space before negative numbers to resolve CVE-2024-44905

### DIFF
--- a/orm/format_test.go
+++ b/orm/format_test.go
@@ -146,6 +146,30 @@ var formatTests = []formatTest{
 		paramsMap: paramsMap{"string": "my_value"},
 		wanted:    "?string",
 	},
+
+	{
+		q:      "select 1-?0, 1.0-?1, 1.0-?2",
+		params: params{int64(-1), float64(-1.5), math.Inf(-1)},
+		wanted: "select 1- -1, 1.0- -1.5, 1.0-'-Infinity'",
+	},
+	{
+		q:      "select 1+?0, 1.0+?1",
+		params: params{int64(-1), float64(-1.5)},
+		wanted: "select 1+-1, 1.0+-1.5",
+	},
+	{
+		q:      "select 1-?0, ?1",
+		params: params{int64(-1), "foo\n;\nSELECT * FROM passwords;--"},
+		// Without a space before the negative number, the first line ends in a comment
+		wanted: `select 1- -1, 'foo
+;
+SELECT * FROM passwords;--'`,
+	},
+	{
+		q:      "?0",
+		params: params{int64(-1)},
+		wanted: "-1",
+	},
 }
 
 func TestFormatQuery(t *testing.T) {

--- a/types/append.go
+++ b/types/append.go
@@ -17,11 +17,11 @@ func Append(b []byte, v interface{}, flags int) []byte {
 	case bool:
 		return appendBool(b, v)
 	case int32:
-		return strconv.AppendInt(b, int64(v), 10)
+		return appendInt(b, int64(v))
 	case int64:
-		return strconv.AppendInt(b, v, 10)
+		return appendInt(b, v)
 	case int:
-		return strconv.AppendInt(b, int64(v), 10)
+		return appendInt(b, int64(v))
 	case float32:
 		return appendFloat(b, float64(v), flags, 32)
 	case float64:
@@ -60,6 +60,15 @@ func appendBool(dst []byte, v bool) []byte {
 	return append(dst, "FALSE"...)
 }
 
+func appendInt(dst []byte, v int64) []byte {
+	// To avoid accidental comments which can lead to SQL injection, put a space before
+	// negative numbers immediately following a minus sign.
+	if v < 0 && len(dst) > 0 && dst[len(dst)-1] == '-' {
+		dst = append(dst, ' ')
+	}
+	return strconv.AppendInt(dst, v, 10)
+}
+
 func appendFloat(dst []byte, v float64, flags int, bitSize int) []byte {
 	if hasFlag(flags, arrayFlag) {
 		return appendFloat2(dst, v, flags)
@@ -80,8 +89,18 @@ func appendFloat(dst []byte, v float64, flags int, bitSize int) []byte {
 		if hasFlag(flags, quoteFlag) {
 			return append(dst, "'-Infinity'"...)
 		}
+		// To avoid accidental comments which can lead to SQL injection, put a space before
+		// negative numbers immediately following a minus sign.
+		if v < 0 && len(dst) > 0 && dst[len(dst)-1] == '-' {
+			dst = append(dst, ' ')
+		}
 		return append(dst, "-Infinity"...)
 	default:
+		// To avoid accidental comments which can lead to SQL injection, put a space before
+		// negative numbers immediately following a minus sign.
+		if v < 0 && len(dst) > 0 && dst[len(dst)-1] == '-' {
+			dst = append(dst, ' ')
+		}
 		return strconv.AppendFloat(dst, v, 'f', -1, bitSize)
 	}
 }

--- a/types/append_value.go
+++ b/types/append_value.go
@@ -24,7 +24,7 @@ type AppenderFunc func([]byte, reflect.Value, int) []byte
 
 var appenders []AppenderFunc
 
-//nolint
+// nolint
 func init() {
 	appenders = []AppenderFunc{
 		reflect.Bool:          appendBoolValue,
@@ -148,7 +148,7 @@ func appendBoolValue(b []byte, v reflect.Value, _ int) []byte {
 }
 
 func appendIntValue(b []byte, v reflect.Value, _ int) []byte {
-	return strconv.AppendInt(b, v.Int(), 10)
+	return appendInt(b, v.Int())
 }
 
 func appendUintValue(b []byte, v reflect.Value, _ int) []byte {


### PR DESCRIPTION
Add mandatory space before negative numbers to resolve CVE-2024-44905

The fix was adapted from https://github.com/uptrace/bun/commit/8067a8f13f8d22fb57b76d6800f7aefc12b044cd

See:
- https://github.com/advisories/GHSA-6xp3-p59p-q4fj
- https://github.com/uptrace/bun/pull/1225
- https://github.com/uptrace/bun/issues/1224