### PR TITLE
Fix copyTo after error copyTo

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -747,6 +747,27 @@ var _ = Describe("CopyFrom/CopyTo", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(count).To(Equal(0))
 	})
+
+	// Without the related fix the test is flaky with ~80% failure rate
+	It("copyTo after error copyTo", func() {
+		conn := db.Conn()
+		defer conn.Close()
+
+		_, err := conn.Exec("CREATE TEMP TABLE copy_overflow(n bigint)")
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = conn.Exec("INSERT INTO copy_overflow VALUES (1), (9223372036854775807), (3)")
+		Expect(err).NotTo(HaveOccurred())
+
+		var buf1 bytes.Buffer
+		_, err = conn.CopyTo(&buf1, "COPY (SELECT n::int FROM copy_overflow) TO STDOUT")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("out of range"))
+
+		var buf2 bytes.Buffer
+		_, err = conn.CopyTo(&buf2, "COPY (SELECT 1) TO STDOUT")
+		Expect(err).NotTo(HaveOccurred())
+	})
 })
 
 var _ = Describe("CountEstimate", func() {

--- a/messages.go
+++ b/messages.go
@@ -1195,7 +1195,9 @@ func readCopyData(rd *pool.ReaderContext, w io.Writer) (*result, error) {
 			if err != nil {
 				return nil, err
 			}
-			return nil, e
+			if firstErr == nil {
+				firstErr = e
+			}
 		case noticeResponseMsg:
 			if err := logNotice(rd, msgLen); err != nil {
 				return nil, err


### PR DESCRIPTION
Sometimes when error is received in .CopyTo some bytes get left in buffer because of early exit in handling errorResponseMsg. The bytes that left can corrupt the next call, leading to `unexpected message` error